### PR TITLE
Add installation and exporting of CMake targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,11 +63,14 @@ coverage_html/
 # Doxygen output
 docs/doxygen_out
 
-# Vim files
+# Editor files
 # -------------------------------------------------------------------
 *.swp
 .ycm_extra_conf.py
 *.swo
+*.vscode/
+
+
 
 # Gurobi
 # -------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes since last release
 * Fixed [#34](https://github.com/oxfordcontrol/osqp/issues/34)
 * Allow `eps_rel=0` [#40](https://github.com/oxfordcontrol/osqp/issues/40)
 * Fixed bug when calling `osqp_solve` or `osqp_cleanup` after failed linear system initialization
+* Add "install" CMake target and installation of CMake configuration files
 
 
 Version 0.2.1 (25 November 2017)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,27 @@ include_directories(${linsys_solvers_includes})
 
 add_library (osqpstatic STATIC ${osqp_src} ${osqp_headers} ${linsys_solvers})
 
+# Declare include directories for the cmake exported target
+target_include_directories(osqpstatic 
+                           INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+
+# Install  Library
+# ----------------------------------------------
+
+include(GNUInstallDirs)
+
+install(TARGETS osqpstatic
+        EXPORT  ${PROJECT_NAME}
+        LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+        
+# Install  Headers
+# ----------------------------------------------
+
+install(FILES ${osqp_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 if (MATLAB)
 target_link_libraries (osqpstatic ${Matlab_LIBRARIES})
@@ -274,6 +295,18 @@ if (NOT PYTHON AND NOT MATLAB)
     # Create osqp shared library
     # NB: Add all the linear system solvers here
     add_library (osqp SHARED ${osqp_src} ${osqp_headers} ${linsys_solvers})
+    
+    # Declare include directories for the cmake exported target
+    target_include_directories(osqp 
+                               INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                         "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+
+    # Install osqp shared library 
+    install(TARGETS osqp
+            EXPORT  ${PROJECT_NAME}
+            LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
     # Create demo executable (linked to static library)
     add_executable (osqp_demo ${PROJECT_SOURCE_DIR}/examples/osqp_demo.c)
@@ -281,6 +314,31 @@ if (NOT PYTHON AND NOT MATLAB)
 
 endif (NOT PYTHON AND NOT MATLAB)
 
+# Create CMake packages for the build directory 
+# ----------------------------------------------
+include(CMakePackageConfigHelpers)
+
+export(EXPORT ${PROJECT_NAME}
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/osqp-targets.cmake"
+  NAMESPACE osqp::)
+
+if(NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/osqp-config.cmake)
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/osqp-config.cmake "include(\"\${CMAKE_CURRENT_LIST_DIR}/osqp-targets.cmake\")\n")
+endif()
+
+
+# Create CMake packages for the install directory 
+# ----------------------------------------------
+
+set(ConfigPackageLocation lib/cmake/osqp)
+
+install(EXPORT ${PROJECT_NAME} 
+        FILE osqp-targets.cmake
+        NAMESPACE osqp::
+        DESTINATION ${ConfigPackageLocation})
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/osqp-config.cmake
+        DESTINATION ${ConfigPackageLocation})
 
 # Add testing
 # ----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Minimum version required
 cmake_minimum_required (VERSION 3.2)
 
-
-
-
-
 # Project name
 project (osqp)
 
@@ -119,12 +115,6 @@ if (NOT MSVC)
         set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} -lrt -ldl")
     endif()
 endif (NOT MSVC)
-
-
-# Include header directory
-# ----------------------------------------------
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-
 
 # Set sources
 # ----------------------------------------------
@@ -246,39 +236,39 @@ endif (MATLAB)
 
 
 
-# Create  Library
+# Create Static Library
 # ----------------------------------------------
 
 # Add linear system solvers cumulative library
 add_subdirectory(lin_sys)
 
-# Add linear system solvers interfaces includes
-include_directories(${linsys_solvers_includes})
-
-
+# Static library
 add_library (osqpstatic STATIC ${osqp_src} ${osqp_headers} ${linsys_solvers})
+
+# Include directories for linear system solvers
+target_include_directories(osqpstatic PRIVATE ${linsys_solvers_includes})
 
 # Declare include directories for the cmake exported target
 target_include_directories(osqpstatic 
-                           INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-                                     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+                           PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/osqp>")
 
-# Install  Library
+# Install Static Library
 # ----------------------------------------------
 
 include(GNUInstallDirs)
 
 install(TARGETS osqpstatic
         EXPORT  ${PROJECT_NAME}
-        LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
+        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
         
-# Install  Headers
+# Install Headers
 # ----------------------------------------------
 
-install(FILES ${osqp_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES ${osqp_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/osqp")
+
+
 
 if (MATLAB)
 target_link_libraries (osqpstatic ${Matlab_LIBRARIES})
@@ -296,17 +286,18 @@ if (NOT PYTHON AND NOT MATLAB)
     # NB: Add all the linear system solvers here
     add_library (osqp SHARED ${osqp_src} ${osqp_headers} ${linsys_solvers})
     
+    # Include directories for linear system solvers
+    target_include_directories(osqp PRIVATE ${linsys_solvers_includes})
+
     # Declare include directories for the cmake exported target
     target_include_directories(osqp 
-                               INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-                                         "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+                               PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+                                      "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/osqp>")
 
     # Install osqp shared library 
     install(TARGETS osqp
             EXPORT  ${PROJECT_NAME}
-            LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-            ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-            RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
+            LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
     # Create demo executable (linked to static library)
     add_executable (osqp_demo ${PROJECT_SOURCE_DIR}/examples/osqp_demo.c)
@@ -339,6 +330,22 @@ install(EXPORT ${PROJECT_NAME}
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/osqp-config.cmake
         DESTINATION ${ConfigPackageLocation})
+
+
+
+# Add uninstall command
+# ----------------------------------------------
+if(NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/configure/cmake/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
+
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()
+
+
 
 # Add testing
 # ----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,9 @@ include(GNUInstallDirs)
 
 install(TARGETS osqpstatic
         EXPORT  ${PROJECT_NAME}
-        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
         
 # Install Headers
@@ -297,7 +299,9 @@ if (NOT PYTHON AND NOT MATLAB)
     # Install osqp shared library 
     install(TARGETS osqp
             EXPORT  ${PROJECT_NAME}
-            LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+            LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
     # Create demo executable (linked to static library)
     add_executable (osqp_demo ${PROJECT_SOURCE_DIR}/examples/osqp_demo.c)

--- a/configure/cmake/cmake_uninstall.cmake.in
+++ b/configure/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/docs/installation/CC++.rst
+++ b/docs/installation/CC++.rst
@@ -23,3 +23,21 @@ Sources
 The OSQP libraries can also be compiled from sources. For more details see :ref:`build_from_sources`.
 
 
+Including OSQP in CMake projects
+--------------------------------
+If you compiled OSQP from sources and followed the CMake installation instructions in :ref:`install_the_binaries` section, you can include the package in another CMake project with the following lines depending on whether you need a shared or a static library
+
+.. code::
+
+   # Find OSQP library and headers
+   find_package(osqp REQUIRED)
+
+   # Link the OSQP shared library
+   target_link_libraries(yourTarget PRIVATE osqp::osqp)
+
+   # or...
+
+   # Link the OSQP static library
+   target_link_libraries(yourTarget PRIVATE osqp::osqpstatic)
+
+

--- a/docs/installation/sources.rst
+++ b/docs/installation/sources.rst
@@ -112,3 +112,26 @@ The compilation will generate the demo :code:`osqp_demo` and the unittests :code
 
 
 Once the sources are built, the generated static :code:`build/out/libosqpstatic.a` and shared :code:`build/out/libosqp.ext` libraries can be used to interface any C/C++ software to OSQP (see :ref:`install_osqp_libs` installation).
+
+.. _install_the_binaries:
+
+Install the binaries
+--------------------
+
+To install the generated libraries and headers to a system-wide location compatible with `GNU standards <http://www.gnu.org/prep/standards/html_node/Directory-Variables.html>`_ it is just necessary to run
+
+.. code:: bash
+   
+   cmake --build . --target install
+
+This code installs the libraries in :code:`libdir` and the headers into :code:`includedir/osqp`. For mode details see the defaults folders on the `GNU standards <http://www.gnu.org/prep/standards/html_node/Directory-Variables.html>`_ website.
+To change the installation prefix, in the "Create Makefiles" step above, you need to specify the destination folder as :code:`cmake -DCMAKE_INSTALL_PREFIX:PATH=myfolder ..`.
+
+
+We provided also an uninstall routine to remove the copied files by running 
+
+.. code:: bash
+   
+   cmake --build . --target uninstall
+
+Note that this corresponds to running :code:`make install` and :code:`make uninstall` on unix machines.

--- a/lin_sys/direct/CMakeLists.txt
+++ b/lin_sys/direct/CMakeLists.txt
@@ -8,11 +8,11 @@ add_subdirectory(suitesparse)
 # create suitesparse ldl object library
 add_library(linsys_suitesparse_ldl OBJECT ${suitesparse_ldl_sources})
 
-target_include_directories(linsys_suitesparse_ldl PRIVATE ${suitesparse_ldl_includes})
+target_include_directories(linsys_suitesparse_ldl PRIVATE ${suitesparse_ldl_includes}  ${PROJECT_SOURCE_DIR}/include)
 
 set(direct_linsys_solvers $<TARGET_OBJECTS:linsys_suitesparse_ldl>)
 
-set(direct_linsys_solvers_includes ${suitesparse_ldl_includes})
+set(direct_linsys_solvers_includes "${CMAKE_CURRENT_SOURCE_DIR}/suitesparse/")
 
 
 # Add other solvers if embedded option is false
@@ -28,11 +28,11 @@ if (ENABLE_MKL_PARDISO)
 	add_library(linsys_pardiso OBJECT ${pardiso_sources})
 
   # Add parent directory for library handler
-	target_include_directories(linsys_pardiso PRIVATE  ${pardiso_includes})
+	target_include_directories(linsys_pardiso PRIVATE  ${pardiso_includes} ${PROJECT_SOURCE_DIR}/include)
 
 	set(direct_linsys_solvers ${direct_linsys_solvers} $<TARGET_OBJECTS:linsys_pardiso>)
 
-	set(direct_linsys_solvers_includes ${direct_linsys_solvers_includes} ${pardiso_includes})
+	set(direct_linsys_solvers_includes "${direct_linsys_solvers_includes};${CMAKE_CURRENT_SOURCE_DIR}/pardiso/")
 endif()
 
 


### PR DESCRIPTION
These modifications simplify the installation of the library using CMake and the consumption of the library from CMake downstream projects.

In particular, if the default installation prefix is used then the library can be easily used in downstream project as: 
~~~
find_package(osqp REQUIRED)

# Link the osqp shared library
target_link_libraries(yourTarget PRIVATE osqp::osqp)

# Link the osqp static library
target_link_libraries(yourTarget PRIVATE osqp::osqpstatic)
~~~

See https://cmake.org/cmake/help/v3.2/command/find_package.html#command:find_package and https://cmake.org/cmake/help/v3.2/manual/cmake-packages.7.html for more information about CMake config packages. 

I would be happy to document this somewhere, but the only existing instructions for C/C++ are the one in https://github.com/oxfordcontrol/osqp/blob/17809ff56b3b9e5cefc7fa63514c47ca6d928d83/docs/installation/CC%2B%2B.rst , that refer to the Bintray binaries, and I don't know how these binaries are generated. 