### PR TITLE
Enable compilation with VS 2008 for Python 2.7

### DIFF
--- a/lin_sys/direct/suitesparse/suitesparse_ldl.c
+++ b/lin_sys/direct/suitesparse/suitesparse_ldl.c
@@ -101,11 +101,12 @@ static c_int LDL_factor(csc *A,  suitesparse_ldl_solver * p){
 static c_int permute_KKT(csc ** KKT, suitesparse_ldl_solver * p, c_int Pnz, c_int Anz, c_int m, c_int * PtoKKT, c_int * AtoKKT, c_int * rhotoKKT){
     c_float *info;
     c_int amd_status;
-    info = (c_float *)c_malloc(AMD_INFO * sizeof(c_float));
     c_int * Pinv;
     csc *KKT_temp;
     c_int * KtoPKPt;
     c_int i; // Indexing
+
+    info = (c_float *)c_malloc(AMD_INFO * sizeof(c_float));
 
     // Compute permutation metrix P using AMD
     #ifdef DLONG

--- a/src/util.c
+++ b/src/util.c
@@ -58,10 +58,10 @@ void print_header(void) {
 void print_setup_header(const OSQPWorkspace *work) {
   OSQPData *data;
   OSQPSettings *settings;
+  c_int nnz; // Number of nonzeros in the problem
 
   data     = work->data;
   settings = work->settings;
-  c_int nnz; // Number of nonzeros in the problem
 
   // Number of nonzeros
   nnz = data->P->nzmax + data->A->p[data->A->n];


### PR DESCRIPTION
These simple fixes will enable this code to be compiled with Visual Studio 2008, which should simplify the building of a Python 2.7 module considerably. 

See https://github.com/oxfordcontrol/osqp-python/pull/6