### PR TITLE
Check nonconvex problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+* Added check for nonconvex cost function (negative semidefinite `P`).
+
+
 Version 0.3.1 (10 June 2018)
 ----------------------------
 * Fixed [#62](https://github.com/oxfordcontrol/osqp/issues/62).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required (VERSION 3.2)
 # Project name
 project (osqp)
 
+# Export compile commands
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Set the output folder where your program will be created
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/out)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/out)

--- a/include/constants.h
+++ b/include/constants.h
@@ -27,6 +27,7 @@ extern "C" {
 # ifdef PROFILING
 #  define OSQP_TIME_LIMIT_REACHED (-6)
 # endif // ifdef PROFILING
+# define OSQP_NON_CVX (-7)           /* problem non convex */
 # define OSQP_UNSOLVED (-10) /* Unsolved. Only setup function has been called */
 
 
@@ -73,6 +74,20 @@ static const char *LINSYS_SOLVER_NAME[] = {
 
 # define MIN_SCALING (1e-04) ///< Minimum scaling value
 # define MAX_SCALING (1e+04) ///< Maximum scaling value
+
+
+# ifndef OSQP_NULL
+#  define OSQP_NULL 0
+# endif /* ifndef OSQP_NULL */
+
+# ifndef OSQP_NAN
+#  define OSQP_NAN ((c_float)0.0/0.0) // Not a Number
+# endif /* ifndef OSQP_NAN */
+
+# ifndef OSQP_INFTY
+#  define OSQP_INFTY ((c_float)1e20) // Infinity
+# endif /* ifndef OSQP_INFTY */
+
 
 # if EMBEDDED != 1
 #  define ADAPTIVE_RHO (1)

--- a/include/glob_opts.h
+++ b/include/glob_opts.h
@@ -96,19 +96,6 @@ typedef float c_float;  /* for numerical values  */
 # endif /* ifndef DFLOAT */
 
 
-/* Use customized constants -----------------------------------------------   */
-# ifndef OSQP_NULL
-#  define OSQP_NULL 0
-# endif /* ifndef OSQP_NULL */
-
-# ifndef OSQP_NAN
-#  define OSQP_NAN ((c_float)0x7ff8000000000000) // Not a Number
-# endif /* ifndef OSQP_NAN */
-
-# ifndef OSQP_INFTY
-#  define OSQP_INFTY ((c_float)1e20) // Infinity
-# endif /* ifndef OSQP_INFTY */
-
 /* Use customized operations */
 
 # ifndef c_absval

--- a/lin_sys/direct/pardiso/pardiso_loader.c
+++ b/lin_sys/direct/pardiso/pardiso_loader.c
@@ -1,6 +1,9 @@
 #include "lib_handler.h"
 #include "pardiso_loader.h"
 
+#include "glob_opts.h"
+#include "constants.h"
+
 #ifdef IS_WINDOWS
 #define PARDISOLIBNAME "mkl_rt." SHAREDLIBEXT
 #else
@@ -39,7 +42,7 @@ void pardiso(void** pt, const c_int* maxfct, const c_int* mnum,
             // Call function pardiso only if it has been initialized
 	    func_pardiso(pt, maxfct, mnum, mtype, phase, n, a, ia, ja,
 			 perm, nrhs, iparm, msglvl, b, x, error);
-	} 
+	}
 	else
 	{
 #ifdef PRINTING

--- a/lin_sys/direct/pardiso/pardiso_loader.h
+++ b/lin_sys/direct/pardiso/pardiso_loader.h
@@ -5,7 +5,6 @@
 extern "C" {
 #endif
 
-#include "glob_opts.h"
 
 
 /**

--- a/lin_sys/lib_handler.c
+++ b/lin_sys/lib_handler.c
@@ -1,6 +1,8 @@
 #include "lib_handler.h"
 #include <ctype.h> // Needed for tolower functions
 
+#include "constants.h"
+
 soHandle_t lh_load_lib(const char *libName) {
     soHandle_t h = OSQP_NULL;
 

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -526,22 +526,6 @@ static c_int has_solution(OSQPInfo * info){
 
 }
 
-static c_int has_primal_solution(OSQPInfo * info){
-
-  return ((info->status_val != OSQP_PRIMAL_INFEASIBLE) &&
-      (info->status_val != OSQP_PRIMAL_INFEASIBLE_INACCURATE) &&
-      (info->status_val != OSQP_NON_CVX));
-
-}
-
-static c_int has_dual_solution(OSQPInfo * info){
-
-  return ((info->status_val != OSQP_DUAL_INFEASIBLE) &&
-      (info->status_val != OSQP_DUAL_INFEASIBLE_INACCURATE) &&
-      (info->status_val != OSQP_NON_CVX));
-
-}
-
 void store_solution(OSQPWorkspace *work) {
 #ifndef EMBEDDED
   c_float norm_vec;

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -384,7 +384,7 @@ c_int osqp_solve(OSQPWorkspace *work) {
       update_status(work->info, OSQP_TIME_LIMIT_REACHED);
 # ifdef PRINTING
 
-      if (work->settings->verbose) c_print("Run time limit reached\n");
+      if (work->settings->verbose) c_print("run time limit reached\n");
 # endif /* ifdef PRINTING */
       exitflag = 1;
       goto exit;
@@ -499,7 +499,9 @@ c_int osqp_solve(OSQPWorkspace *work) {
       }
     }
 #endif // EMBEDDED != 1
+
   }        // End of ADMM for loop
+
 
   // Update information and check termination condition if it hasn't been done
   // during last iteration (max_iter reached or check_termination disabled)

--- a/tests/generate_tests_data.py
+++ b/tests/generate_tests_data.py
@@ -2,6 +2,7 @@
 
 import basic_qp.generate_problem
 import basic_qp2.generate_problem
+import non_cvx.generate_problem
 import lin_alg.generate_problem
 import solve_linsys.generate_problem
 import primal_infeasibility.generate_problem

--- a/tests/non_cvx/CMakeLists.txt
+++ b/tests/non_cvx/CMakeLists.txt
@@ -1,0 +1,13 @@
+get_directory_property(headers
+                        DIRECTORY ${PROJECT_SOURCE_DIR}/tests
+                        DEFINITION headers)
+
+set(headers ${headers}
+${CMAKE_CURRENT_SOURCE_DIR}/test_non_cvx.h PARENT_SCOPE)
+
+get_directory_property(codegen_headers
+                        DIRECTORY ${PROJECT_SOURCE_DIR}/tests
+                        DEFINITION codegen_headers)
+
+set(codegen_headers ${codegen_headers}
+        ${CMAKE_CURRENT_SOURCE_DIR}/data.h PARENT_SCOPE)

--- a/tests/non_cvx/generate_problem.py
+++ b/tests/non_cvx/generate_problem.py
@@ -1,0 +1,24 @@
+import numpy as np
+import scipy.sparse as spa
+import utils.codegen_utils as cu
+
+P = spa.csc_matrix(np.array([[2., 5.], [5., 1.]]))
+q = np.array([3., 4.])
+
+A = spa.csc_matrix(np.array([[-1.0, 0.], [0., -1.], [-1., 3.],
+                             [2., 5.], [3., 4]]))
+l = -np.inf * np.ones(A.shape[0])
+u = np.array([0., 0., -15., 100., 80.])
+
+n = P.shape[0]
+m = A.shape[0]
+
+# New data
+q_new = np.array([1., 1.])
+u_new = np.array([-2., 0., -20., 100., 80.])
+
+# Generate problem solutions
+sols_data = {'status_test': 'problem non convex'}
+
+# Generate problem data
+cu.generate_problem_data(P, q, A, l, u, 'non_cvx', sols_data)

--- a/tests/non_cvx/test_non_cvx.h
+++ b/tests/non_cvx/test_non_cvx.h
@@ -1,0 +1,64 @@
+#include "osqp.h"    // OSQP API
+#include "minunit.h" // Basic testing script header
+
+
+#include "non_cvx/data.h"
+
+
+static char* test_non_cvx_solve()
+{
+  /* local variables */
+  c_int exitflag = 0; // No errors
+
+  // Problem settings
+  OSQPSettings *settings = (OSQPSettings *)c_malloc(sizeof(OSQPSettings));
+
+  // Structures
+  OSQPWorkspace *work; // Workspace
+  OSQPData *data;      // Data
+  non_cvx_sols_data *sols_data;
+
+
+  // Populate data
+  data      = generate_problem_non_cvx();
+  sols_data = generate_problem_non_cvx_sols_data();
+
+
+  // Define Solver settings as default
+  osqp_set_default_settings(settings);
+  settings->verbose = 1;
+
+  // Setup workspace
+  work = osqp_setup(data, settings);
+
+  // Setup correct
+  mu_assert("Non Convex test solve: Setup error!", work != OSQP_NULL);
+
+  // Solve Problem first time
+  osqp_solve(work);
+
+  // Compare solver statuses
+  mu_assert("Non Convex test solve: Error in solver status!",
+            work->info->status_val == sols_data->status_test);
+
+  // Compare objective values
+  mu_assert("Non Convex test solve: Error in objective value!",
+            work->info->obj_val != work->info->obj_val);
+
+  // Clean workspace
+  osqp_cleanup(work);
+
+  // Cleanup settings and data
+  c_free(settings);
+  clean_problem_non_cvx(data);
+  clean_problem_non_cvx_sols_data(sols_data);
+
+  return 0;
+}
+
+static char* test_non_cvx()
+{
+  mu_run_test(test_non_cvx_solve);
+
+  return 0;
+}

--- a/tests/osqp_tester.c
+++ b/tests/osqp_tester.c
@@ -13,6 +13,7 @@
 #include "solve_linsys/test_solve_linsys.h"
 #include "basic_qp/test_basic_qp.h"
 #include "basic_qp2/test_basic_qp2.h"
+#include "non_cvx/test_non_cvx.h"
 #include "primal_infeasibility/test_primal_infeasibility.h"
 #include "primal_dual_infeasibility/test_primal_dual_infeasibility.h"
 #include "update_matrices/test_update_matrices.h"
@@ -26,6 +27,7 @@ static char* all_tests() {
   mu_run_test(test_solve_linsys);
   mu_run_test(test_basic_qp);
   mu_run_test(test_basic_qp2);
+  mu_run_test(test_non_cvx);
   mu_run_test(test_primal_infeasibility);
   mu_run_test(test_primal_dual_infeasibility);
   mu_run_test(test_update_matrices);


### PR DESCRIPTION
Added check for nonconvex problem when the residuals are too large (i.e., `2 * OSQP_INFTY`). I have added a unit test to check it.

Added a new output status: `OSQP_NON_CVX`

TODO:

- [ ] Update the status in all the interfaces.