### PR TITLE
Namespace interrupt functions and tic/toc

### DIFF
--- a/include/ctrlc.h
+++ b/include/ctrlc.h
@@ -34,18 +34,18 @@ bool utSetInterruptEnabled(bool);
 /**
  * Start listner for ctrl-c interrupts
  */
-void startInterruptListener(void);
+void osqp_start_interrupt_listener(void);
 
 /**
  * End listner for ctrl-c interrupts
  */
-void endInterruptListener(void);
+void osqp_end_interrupt_listener(void);
 
 /**
  * Check if the solver has been interrupted
  * @return  Boolean indicating if the solver has been interrupted
  */
-int  isInterrupted(void);
+int osqp_is_interrupted(void);
 
 
 # ifdef __cplusplus

--- a/include/util.h
+++ b/include/util.h
@@ -143,14 +143,14 @@ struct OSQP_TIMER {
  * Start timer
  * @param t Timer object
  */
-void    tic(OSQPTimer *t);
+void    osqp_tic(OSQPTimer *t);
 
 /**
  * Report time
  * @param  t Timer object
  * @return   Reported time
  */
-c_float toc(OSQPTimer *t);
+c_float osqp_toc(OSQPTimer *t);
 
 # endif /* END #ifdef PROFILING */
 

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -625,7 +625,7 @@ void update_info(OSQPWorkspace *work,
 
   // Update timing
 #ifdef PROFILING
-  *run_time = toc(work->timer);
+  *run_time = osqp_toc(work->timer);
 #endif /* ifdef PROFILING */
 
 #ifdef PRINTING

--- a/src/ctrlc.c
+++ b/src/ctrlc.c
@@ -28,7 +28,7 @@ int osqp_is_interrupted(void) {
 #elif defined IS_WINDOWS
 
 static int int_detected;
-BOOL WINAPI handle_ctrlc(DWORD dwCtrlType) {
+static BOOL WINAPI handle_ctrlc(DWORD dwCtrlType) {
   if (dwCtrlType != CTRL_C_EVENT) return FALSE;
 
   int_detected = 1;

--- a/src/ctrlc.c
+++ b/src/ctrlc.c
@@ -13,15 +13,15 @@
 
 static int istate;
 
-void startInterruptListener(void) {
+void osqp_start_interrupt_listener(void) {
   istate = utSetInterruptEnabled(1);
 }
 
-void endInterruptListener(void) {
+void osqp_end_interrupt_listener(void) {
   utSetInterruptEnabled(istate);
 }
 
-int isInterrupted(void) {
+int osqp_is_interrupted(void) {
   return utIsInterruptPending();
 }
 
@@ -35,16 +35,16 @@ BOOL WINAPI handle_ctrlc(DWORD dwCtrlType) {
   return TRUE;
 }
 
-void startInterruptListener(void) {
+void osqp_start_interrupt_listener(void) {
   int_detected = 0;
   SetConsoleCtrlHandler(handle_ctrlc, TRUE);
 }
 
-void endInterruptListener(void) {
+void osqp_end_interrupt_listener(void) {
   SetConsoleCtrlHandler(handle_ctrlc, FALSE);
 }
 
-int isInterrupted(void) {
+int osqp_is_interrupted(void) {
   return int_detected;
 }
 
@@ -53,11 +53,11 @@ int isInterrupted(void) {
 # include <signal.h>
 static int int_detected;
 struct sigaction oact;
-void handle_ctrlc(int dummy) {
+static void handle_ctrlc(int dummy) {
   int_detected = dummy ? dummy : -1;
 }
 
-void startInterruptListener(void) {
+void osqp_start_interrupt_listener(void) {
   struct sigaction act;
 
   int_detected = 0;
@@ -67,13 +67,13 @@ void startInterruptListener(void) {
   sigaction(SIGINT, &act, &oact);
 }
 
-void endInterruptListener(void) {
+void osqp_end_interrupt_listener(void) {
   struct sigaction act;
 
   sigaction(SIGINT, &oact, &act);
 }
 
-int isInterrupted(void) {
+int osqp_is_interrupted(void) {
   return int_detected;
 }
 

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -103,7 +103,7 @@ OSQPWorkspace* osqp_setup(const OSQPData *data, OSQPSettings *settings) {
   // Start and allocate directly timer
 # ifdef PROFILING
   work->timer = c_malloc(sizeof(OSQPTimer));
-  tic(work->timer);
+  osqp_tic(work->timer);
 # endif /* ifdef PROFILING */
 
 
@@ -227,7 +227,7 @@ OSQPWorkspace* osqp_setup(const OSQPData *data, OSQPSettings *settings) {
   work->info->solve_time  = 0.0;              // Solve time to zero
   work->info->polish_time = 0.0;              // Polish time to zero
   work->info->run_time    = 0.0;              // Total run time to zero
-  work->info->setup_time  = toc(work->timer); // Updater timer information
+  work->info->setup_time  = osqp_toc(work->timer); // Updater timer information
   work->first_run         = 1;
 # endif /* ifdef PROFILING */
 # if EMBEDDED != 1
@@ -311,7 +311,7 @@ c_int osqp_solve(OSQPWorkspace *work) {
 
 
 #ifdef PROFILING
-  tic(work->timer); // Start timer
+  osqp_tic(work->timer); // Start timer
 #endif /* ifdef PROFILING */
 
 
@@ -326,7 +326,7 @@ c_int osqp_solve(OSQPWorkspace *work) {
 #ifdef CTRLC
 
   // initialize Ctrl-C support
-  startInterruptListener();
+  osqp_start_interrupt_listener();
 #endif /* ifdef CTRLC */
 
   // Initialize variables (cold start or warm start depending on settings)
@@ -357,7 +357,7 @@ c_int osqp_solve(OSQPWorkspace *work) {
 #ifdef CTRLC
 
     // Check the interrupt signal
-    if (isInterrupted()) {
+    if (osqp_is_interrupted()) {
       update_status(work->info, OSQP_SIGINT);
 # ifdef PRINTING
       c_print("Solver interrupted\n");
@@ -373,10 +373,10 @@ c_int osqp_solve(OSQPWorkspace *work) {
     // time
     // is more than the time_limit option.
     if (work->first_run) {
-      temp_run_time = work->info->setup_time + toc(work->timer);
+      temp_run_time = work->info->setup_time + osqp_toc(work->timer);
     }
     else {
-      temp_run_time = toc(work->timer);
+      temp_run_time = osqp_toc(work->timer);
     }
 
     if (work->settings->time_limit &&
@@ -442,7 +442,7 @@ c_int osqp_solve(OSQPWorkspace *work) {
     // of the setup time.
     if (work->settings->adaptive_rho && !work->settings->adaptive_rho_interval) {
       // Check time
-      if (toc(work->timer) >
+      if (osqp_toc(work->timer) >
           work->settings->adaptive_rho_fraction * work->info->setup_time) {
         // Enough time has passed. We now get the number of iterations between
         // the updates.
@@ -560,7 +560,7 @@ c_int osqp_solve(OSQPWorkspace *work) {
 
   /* Update solve time */
 #ifdef PROFILING
-  work->info->solve_time = toc(work->timer);
+  work->info->solve_time = osqp_toc(work->timer);
 #endif /* ifdef PROFILING */
 
 
@@ -608,7 +608,7 @@ exit:
 #ifdef CTRLC
 
   // Restore previous signal handler
-  endInterruptListener();
+  osqp_end_interrupt_listener();
 #endif /* ifdef CTRLC */
   return exitflag;
 }

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -224,15 +224,15 @@ OSQPWorkspace* osqp_setup(const OSQPData *data, OSQPSettings *settings) {
   work->info->status_polish = 0;              // Polishing not performed
   update_status(work->info, OSQP_UNSOLVED);
 # ifdef PROFILING
-  work->info->solve_time  = 0.0;              // Solve time to zero
-  work->info->polish_time = 0.0;              // Polish time to zero
-  work->info->run_time    = 0.0;              // Total run time to zero
+  work->info->solve_time  = 0.0;                   // Solve time to zero
+  work->info->polish_time = 0.0;                   // Polish time to zero
+  work->info->run_time    = 0.0;                   // Total run time to zero
   work->info->setup_time  = osqp_toc(work->timer); // Updater timer information
   work->first_run         = 1;
 # endif /* ifdef PROFILING */
 # if EMBEDDED != 1
-  work->info->rho_updates  = 0;                   // Rho updates set to 0
-  work->info->rho_estimate = work->settings->rho; // Best rho estimate
+  work->info->rho_updates  = 0;                    // Rho updates set to 0
+  work->info->rho_estimate = work->settings->rho;  // Best rho estimate
 # endif /* if EMBEDDED != 1 */
 
   // Print header

--- a/src/polish.c
+++ b/src/polish.c
@@ -210,7 +210,7 @@ c_int polish(OSQPWorkspace *work) {
   c_float *pol_sol; // Polished solution
 
 #ifdef PROFILING
-  tic(work->timer); // Start timer
+  osqp_tic(work->timer); // Start timer
 #endif /* ifdef PROFILING */
 
   // Form Ared by assuming the active constraints and store in work->pol->Ared

--- a/src/util.c
+++ b/src/util.c
@@ -229,13 +229,13 @@ OSQPSettings* copy_settings(OSQPSettings *settings) {
 // Windows
 # ifdef IS_WINDOWS
 
-void tic(OSQPTimer *t)
+void osqp_tic(OSQPTimer *t)
 {
   QueryPerformanceFrequency(&t->freq);
   QueryPerformanceCounter(&t->tic);
 }
 
-c_float toc(OSQPTimer *t)
+c_float osqp_toc(OSQPTimer *t)
 {
   QueryPerformanceCounter(&t->toc);
   return (t->toc.QuadPart - t->tic.QuadPart) / (c_float)t->freq.QuadPart;
@@ -244,13 +244,13 @@ c_float toc(OSQPTimer *t)
 // Mac
 # elif defined IS_MAC
 
-void tic(OSQPTimer *t)
+void osqp_tic(OSQPTimer *t)
 {
   /* read current clock cycles */
   t->tic = mach_absolute_time();
 }
 
-c_float toc(OSQPTimer *t)
+c_float osqp_toc(OSQPTimer *t)
 {
   uint64_t duration; /* elapsed time in clock cycles*/
 
@@ -269,13 +269,13 @@ c_float toc(OSQPTimer *t)
 # else  /* ifdef IS_WINDOWS */
 
 /* read current time */
-void tic(OSQPTimer *t)
+void osqp_tic(OSQPTimer *t)
 {
   clock_gettime(CLOCK_MONOTONIC, &t->tic);
 }
 
 /* return time passed since last call to tic on this timer */
-c_float toc(OSQPTimer *t)
+c_float osqp_toc(OSQPTimer *t)
 {
   struct timespec temp;
 


### PR DESCRIPTION
Avoids naming conflicts with ECOS.
See #72 and #67.

I added `static` to the unix version of `handle_ctrlc` because it's internal to ctrlc.c. I'm not confident enough to touch the windows version and also can't test that it works locally.