### PR TITLE
Remove ctrlc.c from sources when CTRLC is OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,10 @@ else()
     )
 endif()
 
-
+if (NOT CTRLC)
+    list(REMOVE_ITEM osqp_src "src/ctrlc.c")
+    list(REMOVE_ITEM osqp_headers "include/ctrlc.h")
+endif()
 
 # if we are building the Python interface, let's look for Python
 # and set some options


### PR DESCRIPTION
It seems that ctrlc.c is being compiled even when the flag CTRLC is OFF. Any particular reason as to why?
I just added a quick check to see if CTRLC is OFF and removed ctrlc.c/h from source/include files accordingly...