### PR TITLE
Updated docs to reflect new arguments in codegen method

### DIFF
--- a/docs/codegen/matlab.rst
+++ b/docs/codegen/matlab.rst
@@ -19,25 +19,31 @@ The second argument :code:`varargin` specifies additional codegen options
 shown in the following table
 
 
-+-----------------------+-------------------------------------+--------------------------------+
-| Option                | Description                         | Allowed values                 |
-+=======================+=====================================+================================+
-| :code:`project_type`  | Build environment                   | | :code:`''` (default)         |
-|                       |                                     | | :code:`'Makefile'`           |
-|                       |                                     | | :code:`'MinGW Makefiles'`    |
-|                       |                                     | | :code:`'Unix Makefiles'`     |
-|                       |                                     | | :code:`'CodeBlocks'`         |
-|                       |                                     | | :code:`'Xcode'`              |
-+-----------------------+-------------------------------------+--------------------------------+
-| :code:`parameters`    | Problem parameters                  | | :code:`'vectors'` (default)  |
-|                       |                                     | | :code:`'matrices'`           |
-+-----------------------+-------------------------------------+--------------------------------+
-| :code:`mexname`       | Name of the compiled mex interface  | | :code:`'emosqp'` (default)   |
-|                       |                                     | | Nonempty string              |
-+-----------------------+-------------------------------------+--------------------------------+
-| :code:`force_rewrite` | Rewrite existing directory          | | :code:`false` (default)      |
-|                       |                                     | | :code:`true`                 |
-+-----------------------+-------------------------------------+--------------------------------+
++-----------------------+---------------------------------------------------+--------------------------------+
+| Option                | Description                                       | Allowed values                 |
++=======================+===================================================+================================+
+| :code:`project_type`  | Build environment                                 | | :code:`''` (default)         |
+|                       |                                                   | | :code:`'Makefile'`           |
+|                       |                                                   | | :code:`'MinGW Makefiles'`    |
+|                       |                                                   | | :code:`'Unix Makefiles'`     |
+|                       |                                                   | | :code:`'CodeBlocks'`         |
+|                       |                                                   | | :code:`'Xcode'`              |
++-----------------------+---------------------------------------------------+--------------------------------+
+| :code:`parameters`    | Problem parameters                                | | :code:`'vectors'` (default)  |
+|                       |                                                   | | :code:`'matrices'`           |
++-----------------------+---------------------------------------------------+--------------------------------+
+| :code:`mexname`       | Name of the compiled mex interface                | | :code:`'emosqp'` (default)   |
+|                       |                                                   | | Nonempty string              |
++-----------------------+---------------------------------------------------+--------------------------------+
+| :code:`force_rewrite` | Rewrite existing directory                        | | :code:`false` (default)      |
+|                       |                                                   | | :code:`true`                 |
++-----------------------+---------------------------------------------------+--------------------------------+
+| :code:`FLOAT`         | Use :code:`float` type instead of :code:`double`  | | :code:`false` (default)      |
+|                       |                                                   | | :code:`true`                 |
++-----------------------+---------------------------------------------------+--------------------------------+
+| :code:`LONG`          | Use :code:`long long` type instead of :code:`int` | | :code:`true` (default)       |
+|                       |                                                   | | :code:`false`                |
++-----------------------+---------------------------------------------------+--------------------------------+
 
 You can pass the options as field-value pairs, e.g.,
 

--- a/docs/codegen/python.rst
+++ b/docs/codegen/python.rst
@@ -17,25 +17,31 @@ The argument :code:`dir_name` is the name of a directory where the generated
 code is stored.
 Additional codegen options are shown in the following table
 
-+-------------------------+-------------------------------------+--------------------------------+
-| Option                  | Description                         | Allowed values                 |
-+=========================+=====================================+================================+
-| :code:`project_type`    | Build environment                   | | :code:`''` (default)         |
-|                         |                                     | | :code:`'Makefile'`           |
-|                         |                                     | | :code:`'MinGW Makefiles'`    |
-|                         |                                     | | :code:`'Unix Makefiles'`     |
-|                         |                                     | | :code:`'CodeBlocks'`         |
-|                         |                                     | | :code:`'Xcode'`              |
-+-------------------------+-------------------------------------+--------------------------------+
-| :code:`parameters`      | Problem parameters                  | | :code:`'vectors'` (default)  |
-|                         |                                     | | :code:`'matrices'`           |
-+-------------------------+-------------------------------------+--------------------------------+
-| :code:`python_ext_name` | Name of the generated Python module | | :code:`'emosqp'` (default)   |
-|                         |                                     | | Nonempty string              |
-+-------------------------+-------------------------------------+--------------------------------+
-| :code:`force_rewrite`   | Rewrite existing directory          | | :code:`False` (default)      |
-|                         |                                     | | :code:`True`                 |
-+-------------------------+-------------------------------------+--------------------------------+
++-------------------------+---------------------------------------------------+--------------------------------+
+| Option                  | Description                                       | Allowed values                 |
++=========================+===================================================+================================+
+| :code:`project_type`    | Build environment                                 | | :code:`''` (default)         |
+|                         |                                                   | | :code:`'Makefile'`           |
+|                         |                                                   | | :code:`'MinGW Makefiles'`    |
+|                         |                                                   | | :code:`'Unix Makefiles'`     |
+|                         |                                                   | | :code:`'CodeBlocks'`         |
+|                         |                                                   | | :code:`'Xcode'`              |
++-------------------------+---------------------------------------------------+--------------------------------+
+| :code:`parameters`      | Problem parameters                                | | :code:`'vectors'` (default)  |
+|                         |                                                   | | :code:`'matrices'`           |
++-------------------------+---------------------------------------------------+--------------------------------+
+| :code:`python_ext_name` | Name of the generated Python module               | | :code:`'emosqp'` (default)   |
+|                         |                                                   | | Nonempty string              |
++-------------------------+---------------------------------------------------+--------------------------------+
+| :code:`force_rewrite`   | Rewrite existing directory                        | | :code:`False` (default)      |
+|                         |                                                   | | :code:`True`                 |
++-------------------------+---------------------------------------------------+--------------------------------+
+| :code:`FLOAT`           | Use :code:`float` type instead of :code:`double`  | | :code:`False` (default)      |
+|                         |                                                   | | :code:`True`                 |
++-------------------------+---------------------------------------------------+--------------------------------+
+| :code:`LONG`            | Use :code:`long long` type instead of :code:`int` | | :code:`True` (default)       |
+|                         |                                                   | | :code:`False`                |
++-------------------------+---------------------------------------------------+--------------------------------+
 
 The options are passed using named arguments, e.g.,
 


### PR DESCRIPTION
I added new arguments in the `codegen` method both in Matlab and Python. They allow setting `DFLOAT` and `DLONG` flags in `emosqp` interfaces.

Matlab (master branch): https://github.com/oxfordcontrol/osqp-matlab/commit/d76478cae0623f0d2d9da939f4009f7fc9a71318

Python (develop branch): https://github.com/oxfordcontrol/osqp-python/commit/d0ef645d5fd6abd2c9b6368b15f28a6045179219