### PR TITLE
Custom memory allocators

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,7 @@ indent_size = 4
 # Python
 [*.yml]
 indent_size = 2
+
+# CMake
+[CMakeLists.txt]
+indent_size = 4

--- a/.valgrind-suppress.supp
+++ b/.valgrind-suppress.supp
@@ -12,6 +12,13 @@
 }
 
 {
+   ignore mkl_get_max_threads
+   Memcheck:Cond
+   fun:mkl_serv_domain_get_max_threads
+   obj:*
+}
+
+{
    ignore_libiomp_intel
    Memcheck:Cond
    fun:__intel_sse2_strrchr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ----------------
-* Added meaningful return values to internal functions. Changed syntax of `osqp_setup` function. It now returns an exitflag!
+* Added meaningful return values to internal functions. Changed syntax of `osqp_setup` function. It now returns an exitflag.
+* Custom memory allocators via cmake and the configure file
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,13 @@ if (NOT (CMAKE_SIZEOF_VOID_P EQUAL 8))
 endif()
 message(STATUS "Long integers (64bit) are ${DLONG}")
 
+
+option (DEBUG "Debug mode" OFF)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+	set (DEBUG ON)
+	message(STATUS "Debug mode is ${DEBUG}")
+endif()
+
 # Add code coverage
 option (COVERAGE "Perform code coverage" OFF)
 message(STATUS "Code coverage is ${COVERAGE}")
@@ -165,8 +172,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/configure/osqp_configure.h.in
 # ----------------------------------------------
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)  # -fPIC
 
-# Add specific flag for debug
-set(CMAKE_C_FLAGS_DEBUG "-DDDEBUG")
 
 if (NOT MSVC)
 
@@ -177,8 +182,12 @@ if (NOT MSVC)
 	endif(FORTRAN)
     endif()
 
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -g")
+    if (DEBUG)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g")
+    else()
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
+    endif()
+
     set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} -lm")      # Include math
     # Include real time library in linux
     if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,14 @@ if (NOT DEFINED OSQP_FREE)
     set(OSQP_FREE free)
 endif()
 
+#Report on custom user header options.  This is intended to allow
+#users to provide definitions of their own memory functions
+if(OSQP_USER_CONFIG_H)
+  message(STATUS "User custom configuration header: ${OSQP_USER_CONFIG_H}")
+else()
+  message(STATUS "User custom configuration header: none provided")
+endif()
+
 #Report the memory management configuration.   If matlab
 #or python are used, then report those as special cases
 #since we implement custom internal wrappers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,52 @@ option (COVERAGE "Perform code coverage" OFF)
 message(STATUS "Code coverage is ${COVERAGE}")
 
 
+# Memory allocators
+# ----------------------------------------------
+
+# If user defined functions are not provided for
+# malloc/calloc/realloc/free, then provide defaults
+if (NOT DEFINED OSQP_MALLOC)
+    set(OSQP_MALLOC malloc)
+endif()
+if (NOT DEFINED OSQP_CALLOC)
+    set(OSQP_CALLOC calloc)
+endif()
+if (NOT DEFINED OSQP_REALLOC)
+    set(OSQP_REALLOC realloc)
+endif()
+if (NOT DEFINED OSQP_FREE)
+    set(OSQP_FREE free)
+endif()
+
+#Report the memory management configuration.   If matlab
+#or python are used, then report those as special cases
+#since we implement custom internal wrappers.
+#if EMBEDDED is on, then report instead that no allocators
+#are required, even though function names will have been
+#assigned above as placeholders
+
+if(EMBEDDED)
+  message(STATUS "OSQP allocators: None required since we are building EMBEDDED")
+
+elseif(MATLAB)
+  message(STATUS "OSQP allocators: OSQP/Mathworks wrappers assigned")
+
+elseif(PYTHON)
+  message(STATUS "OSQP allocators: OSQP/Python wrappers assigned")
+
+else()
+  message(STATUS "OSQP allocators: OSQP_MALLOC is ${OSQP_MALLOC}")
+  message(STATUS "OSQP allocators: OSQP_CALLOC is ${OSQP_CALLOC}")
+  message(STATUS "OSQP allocators: OSQP_REALLOC is ${OSQP_REALLOC}")
+  message(STATUS "OSQP allocators: OSQP_FREE is ${OSQP_FREE}")
+
+endif()
+
+
+
+
+
 # Linear solvers dependencies
 # ---------------------------------------------
 option (ENABLE_MKL_PARDISO "Enable MKL Pardiso solver" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,8 +107,8 @@ message(STATUS "Code coverage is ${COVERAGE}")
 # define c_realloc myrealloc
 # define c_free myfree
 
-if(OSQP_CUSTOM_MEMORY_H)
-	message(STATUS "User custom memory management header: ${OSQP_CUSTOM_MEMORY_H}")
+if(OSQP_CUSTOM_MEMORY)
+	message(STATUS "User custom memory management header: ${OSQP_CUSTOM_MEMORY}")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,37 +98,17 @@ message(STATUS "Code coverage is ${COVERAGE}")
 # Memory allocators
 # ----------------------------------------------
 
-# If user defined functions are not provided for
-# malloc/calloc/realloc/free, then provide defaults
-if (NOT DEFINED OSQP_MALLOC)
-    set(OSQP_MALLOC "malloc")
-endif()
-if (NOT DEFINED OSQP_CALLOC)
-    set(OSQP_CALLOC "calloc")
-endif()
-if (NOT DEFINED OSQP_REALLOC)
-    set(OSQP_REALLOC "realloc")
-endif()
-if (NOT DEFINED OSQP_FREE)
-    set(OSQP_FREE "free")
-endif()
-
 #Report on custom user header options.  This is intended to allow
 #users to provide definitions of their own memory functions
+# The header should define the functions as follows
+#
+# define c_malloc mymalloc
+# define c_calloc mycalloc
+# define c_realloc myrealloc
+# define c_free myfree
+
 if(OSQP_CUSTOM_MEMORY_H)
 	message(STATUS "User custom memory management header: ${OSQP_CUSTOM_MEMORY_H}")
-	if (NOT ((DEFINED OSQP_MALLOC) AND
-		     (DEFINED OSQP_CALLOC) AND
-			 (DEFINED OSQP_REALLOC) AND
-			 (DEFINED OSQP_FREE)))
-		message(FATAL_ERROR "If you pass a custom memory management header you must
-		        specify the names of all the new memory management functions:
-				OSQP_MALLOC, OSQP_CALLOC, OSQP_REALLOC and OSQP_FREE")
-	endif()
-    message(STATUS "OSQP memory management: c_malloc is ${OSQP_MALLOC}")
-    message(STATUS "OSQP memory management: c_calloc is ${OSQP_CALLOC}")
-    message(STATUS "OSQP memory management: c_realloc is ${OSQP_REALLOC}")
-    message(STATUS "OSQP memory management: c_free is ${OSQP_FREE}")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,37 +115,21 @@ endif()
 
 #Report on custom user header options.  This is intended to allow
 #users to provide definitions of their own memory functions
-if(OSQP_USER_CONFIG_H)
-  message(STATUS "User custom configuration header: ${OSQP_USER_CONFIG_H}")
-else()
-  message(STATUS "User custom configuration header: none provided")
+if(OSQP_CUSTOM_MEMORY_H)
+	message(STATUS "User custom memory management header: ${OSQP_CUSTOM_MEMORY_H}")
+	if (NOT ((DEFINED OSQP_MALLOC) AND
+		     (DEFINED OSQP_CALLOC) AND
+			 (DEFINED OSQP_REALLOC) AND
+			 (DEFINED OSQP_FREE)))
+		message(FATAL_ERROR "If you pass a custom memory management header you must
+		        specify the names of all the new memory management functions:
+				OSQP_MALLOC, OSQP_CALLOC, OSQP_REALLOC and OSQP_FREE")
+	endif()
+    message(STATUS "OSQP memory management: c_malloc is ${OSQP_MALLOC}")
+    message(STATUS "OSQP memory management: c_calloc is ${OSQP_CALLOC}")
+    message(STATUS "OSQP memory management: c_realloc is ${OSQP_REALLOC}")
+    message(STATUS "OSQP memory management: c_free is ${OSQP_FREE}")
 endif()
-
-#Report the memory management configuration.   If matlab
-#or python are used, then report those as special cases
-#since we implement custom internal wrappers.
-#if EMBEDDED is on, then report instead that no allocators
-#are required, even though function names will have been
-#assigned above as placeholders
-
-if(EMBEDDED)
-  message(STATUS "OSQP allocators: None required since we are building EMBEDDED")
-
-elseif(MATLAB)
-  message(STATUS "OSQP allocators: OSQP/Mathworks wrappers assigned")
-
-elseif(PYTHON)
-  message(STATUS "OSQP allocators: OSQP/Python wrappers assigned")
-
-else()
-  message(STATUS "OSQP allocators: OSQP_MALLOC is ${OSQP_MALLOC}")
-  message(STATUS "OSQP allocators: OSQP_CALLOC is ${OSQP_CALLOC}")
-  message(STATUS "OSQP allocators: OSQP_REALLOC is ${OSQP_REALLOC}")
-  message(STATUS "OSQP allocators: OSQP_FREE is ${OSQP_FREE}")
-
-endif()
-
-
 
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,16 +94,16 @@ message(STATUS "Code coverage is ${COVERAGE}")
 # If user defined functions are not provided for
 # malloc/calloc/realloc/free, then provide defaults
 if (NOT DEFINED OSQP_MALLOC)
-    set(OSQP_MALLOC malloc)
+    set(OSQP_MALLOC "malloc")
 endif()
 if (NOT DEFINED OSQP_CALLOC)
-    set(OSQP_CALLOC calloc)
+    set(OSQP_CALLOC "calloc")
 endif()
 if (NOT DEFINED OSQP_REALLOC)
-    set(OSQP_REALLOC realloc)
+    set(OSQP_REALLOC "realloc")
 endif()
 if (NOT DEFINED OSQP_FREE)
-    set(OSQP_FREE free)
+    set(OSQP_FREE "free")
 endif()
 
 #Report on custom user header options.  This is intended to allow

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -90,8 +90,7 @@ rm -rf build
 mkdir build
 cd build
 cmake -DUNITTESTS=ON \
-    -DOSQP_CUSTOM_MEMORY_H=../tests/custom_memory/custom_memory.h \
+    -DOSQP_CUSTOM_MEMORY=../tests/custom_memory/custom_memory.h \
     ..
 make
 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
-

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -93,21 +93,21 @@ rm -rf build
 mkdir build
 cd build
 cmake -DUNITTESTS=OFF \
-    -DOSQP_CUSTOM_MEMORY=${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.c \
+    -DOSQP_CUSTOM_MEMORY=${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.h \
     ..
 #make the static library first: it will be missing symbols
 #for the custom memory functions
 make osqpstatic
 #compile the custom memory management functions
-g++ -c ${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.c -o \
-       ${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.o
+g++ -c ${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.c \
+    -o ${TRAVIS_BUILD_DIR}/build/custom_memory.o
 #for testing purposes, just add this to osqp
 #static library.   For real applications, users
 #may prefer to keep it separate and link both
 #to their application
 ar -rcs ${TRAVIS_BUILD_DIR}/build/out/libosqp.a \
-        ${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.o\
-        ${TRAVIS_BUILD_DIR}/build/out/libosqp.a
+        ${TRAVIS_BUILD_DIR}/build/custom_memory.o
+
 #now make the rest of the demos and test
 make osqp_demo
 ${TRAVIS_BUILD_DIR}/build/out/osqp_demo

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -90,7 +90,7 @@ rm -rf build
 mkdir build
 cd build
 cmake -DUNITTESTS=ON \
-    -DOSQP_CUSTOM_MEMORY_H=../tests/custom_memory/memory.h \
+    -DOSQP_CUSTOM_MEMORY_H=../tests/custom_memory/custom_memory.h \
     ..
 make
 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -40,7 +40,7 @@ ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
 
 if [[ $TRAVIS_OS_NAME == "linux" ]]; then
     # Check memory with valgrind
-    valgrind --suppressions=${TRAVIS_BUILD_DIR}/.valgrind-suppress.supp --leak-check=full --gen-suppressions=all --error-exitcode=42 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
+    valgrind --suppressions=${TRAVIS_BUILD_DIR}/.valgrind-suppress.supp --leak-check=full --gen-suppressions=all --track-origins=yes --error-exitcode=42 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
     # Perform code coverage
     cd ${TRAVIS_BUILD_DIR}/build
     lcov --directory . --capture -o coverage.info # capture coverage info

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -82,3 +82,16 @@ cd build
 cmake -G "Unix Makefiles" -DPRINTING=OFF -DUNITTESTS=ON ..
 make
 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
+
+
+echo "Test OSQP custom allocators"
+cd ${TRAVIS_BUILD_DIR}
+rm -rf build
+mkdir build
+cd build
+cmake -DUNITTESTS=ON \
+    -DOSQP_CUSTOM_MEMORY_H=../tests/custom_memory/memory.h \
+    ..
+make
+${TRAVIS_BUILD_DIR}/build/out/osqp_tester
+

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -84,13 +84,30 @@ make
 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
 
 
+# Test custom memory management
+# ---------------------------------------------------
+
 echo "Test OSQP custom allocators"
 cd ${TRAVIS_BUILD_DIR}
 rm -rf build
 mkdir build
 cd build
-cmake -DUNITTESTS=ON \
-    -DOSQP_CUSTOM_MEMORY=../tests/custom_memory/custom_memory.h \
+cmake -DUNITTESTS=OFF \
+    -DOSQP_CUSTOM_MEMORY=${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.c \
     ..
-make
-${TRAVIS_BUILD_DIR}/build/out/osqp_tester
+#make the static library first: it will be missing symbols
+#for the custom memory functions
+make osqpstatic
+#compile the custom memory management functions
+g++ -c ${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.c -o \
+       ${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.o
+#for testing purposes, just add this to osqp
+#static library.   For real applications, users
+#may prefer to keep it separate and link both
+#to their application
+ar -rcs ${TRAVIS_BUILD_DIR}/build/out/libosqp.a \
+        ${TRAVIS_BUILD_DIR}/tests/custom_memory/custom_memory.o\
+        ${TRAVIS_BUILD_DIR}/build/out/libosqp.a
+#now make the rest of the demos and test
+make osqp_demo
+${TRAVIS_BUILD_DIR}/build/out/osqp_demo

--- a/configure/osqp_configure.h.in
+++ b/configure/osqp_configure.h.in
@@ -5,7 +5,7 @@
 extern "C" {
 # endif /* ifdef __cplusplus */
 
-/* Operative system */
+/* Operating system */
 #cmakedefine IS_LINUX
 #cmakedefine IS_MAC
 #cmakedefine IS_WINDOWS
@@ -30,6 +30,12 @@ extern "C" {
 
 /* ENABLE_MKL_PARDISO */
 #cmakedefine ENABLE_MKL_PARDISO
+
+/* MEMORY MANAGEMENT FUNCTIONS */
+#cmakedefine OSQP_CALLOC    @OSQP_CALLOC@
+#cmakedefine OSQP_MALLOC    @OSQP_MALLOC@
+#cmakedefine OSQP_REALLOC   @OSQP_REALLOC@
+#cmakedefine OSQP_FREE      @OSQP_FREE@
 
 
 # ifdef __cplusplus

--- a/configure/osqp_configure.h.in
+++ b/configure/osqp_configure.h.in
@@ -5,6 +5,9 @@
 extern "C" {
 # endif /* ifdef __cplusplus */
 
+/* DEBUG */
+#cmakedefine DEBUG
+
 /* Operating system */
 #cmakedefine IS_LINUX
 #cmakedefine IS_MAC

--- a/configure/osqp_configure.h.in
+++ b/configure/osqp_configure.h.in
@@ -35,9 +35,9 @@ extern "C" {
 #cmakedefine ENABLE_MKL_PARDISO
 
 /* MEMORY MANAGEMENT */
-#cmakedefine OSQP_CUSTOM_MEMORY_H
-#ifdef OSQP_CUSTOM_MEMORY_H
-#include "@OSQP_CUSTOM_MEMORY_H@"
+#cmakedefine OSQP_CUSTOM_MEMORY
+#ifdef OSQP_CUSTOM_MEMORY
+#include "@OSQP_CUSTOM_MEMORY@"
 #endif
 
 

--- a/configure/osqp_configure.h.in
+++ b/configure/osqp_configure.h.in
@@ -31,7 +31,13 @@ extern "C" {
 /* ENABLE_MKL_PARDISO */
 #cmakedefine ENABLE_MKL_PARDISO
 
-/* MEMORY MANAGEMENT FUNCTIONS */
+/* MEMORY MANAGEMENT */
+
+#cmakedefine OSQP_USER_CONFIG_H
+#ifdef OSQP_USER_CONFIG_H
+  #include "@OSQP_USER_CONFIG_H@"
+#endif
+
 #cmakedefine OSQP_CALLOC    @OSQP_CALLOC@
 #cmakedefine OSQP_MALLOC    @OSQP_MALLOC@
 #cmakedefine OSQP_REALLOC   @OSQP_REALLOC@

--- a/configure/osqp_configure.h.in
+++ b/configure/osqp_configure.h.in
@@ -35,16 +35,15 @@ extern "C" {
 #cmakedefine ENABLE_MKL_PARDISO
 
 /* MEMORY MANAGEMENT */
-
-#cmakedefine OSQP_USER_CONFIG_H
-#ifdef OSQP_USER_CONFIG_H
-  #include "@OSQP_USER_CONFIG_H@"
+#cmakedefine OSQP_CUSTOM_MEMORY_H
+#ifdef OSQP_CUSTOM_MEMORY_H
+#include "@OSQP_CUSTOM_MEMORY_H@"
+#define c_malloc    @OSQP_MALLOC@
+#define c_calloc    @OSQP_CALLOC@
+#define c_realloc   @OSQP_REALLOC@
+#define c_free      @OSQP_FREE@
 #endif
 
-#cmakedefine OSQP_CALLOC    @OSQP_CALLOC@
-#cmakedefine OSQP_MALLOC    @OSQP_MALLOC@
-#cmakedefine OSQP_REALLOC   @OSQP_REALLOC@
-#cmakedefine OSQP_FREE      @OSQP_FREE@
 
 
 # ifdef __cplusplus

--- a/configure/osqp_configure.h.in
+++ b/configure/osqp_configure.h.in
@@ -38,10 +38,6 @@ extern "C" {
 #cmakedefine OSQP_CUSTOM_MEMORY_H
 #ifdef OSQP_CUSTOM_MEMORY_H
 #include "@OSQP_CUSTOM_MEMORY_H@"
-#define c_malloc    @OSQP_MALLOC@
-#define c_calloc    @OSQP_CALLOC@
-#define c_realloc   @OSQP_REALLOC@
-#define c_free      @OSQP_FREE@
 #endif
 
 

--- a/docs/examples/update-matrices.rst
+++ b/docs/examples/update-matrices.rst
@@ -136,12 +136,12 @@ C
     #include "osqp.h"
 
     int main(int argc, char **argv) {
-        // Define problem data
-        c_float P_x[4] = {4.0, 1.0, 1.0, 2.0, };
+        // Load problem data
+        c_float P_x[3] = {4.0, 1.0, 2.0, };
         c_float P_x_new[3] = {5.0, 1.5, 1.0, };
-        c_int P_nnz = 4;
-        c_int P_i[4] = {0, 1, 0, 1, };
-        c_int P_p[3] = {0, 2, 4, };
+        c_int P_nnz = 3;
+        c_int P_i[3] = {0, 0, 1, };
+        c_int P_p[3] = {0, 1, 3, };
         c_float q[2] = {1.0, 1.0, };
         c_float q_new[2] = {2.0, 3.0, };
         c_float A_x[4] = {1.0, 1.0, 1.0, 1.0, };
@@ -177,7 +177,7 @@ C
         osqp_set_default_settings(settings);
 
         // Setup workspace
-        work = osqp_setup(data, settings);
+        osqp_setup(&work, data, settings);
 
         // Solve problem
         osqp_solve(work);

--- a/docs/examples/update-vectors.rst
+++ b/docs/examples/update-vectors.rst
@@ -136,11 +136,11 @@ C
     #include "osqp.h"
 
     int main(int argc, char **argv) {
-        // Define problem data
-        c_float P_x[4] = {4.0, 1.0, 1.0, 2.0, };
-        c_int P_nnz = 4;
-        c_int P_i[4] = {0, 1, 0, 1, };
-        c_int P_p[3] = {0, 2, 4, };
+        // Load problem data
+        c_float P_x[3] = {4.0, 1.0, 2.0, };
+        c_int P_nnz = 3;
+        c_int P_i[3] = {0, 0, 1, };
+        c_int P_p[3] = {0, 1, 3, };
         c_float q[2] = {1.0, 1.0, };
         c_float q_new[2] = {2.0, 3.0, };
         c_float A_x[4] = {1.0, 1.0, 1.0, 1.0, };
@@ -175,7 +175,7 @@ C
         osqp_set_default_settings(settings);
 
         // Setup workspace
-        work = osqp_setup(data, settings);
+        osqp_setup(&work, data, settings);
 
         // Solve problem
         osqp_solve(work);

--- a/examples/osqp_demo.c
+++ b/examples/osqp_demo.c
@@ -3,10 +3,10 @@
 
 int main(int argc, char **argv) {
   // Load problem data
-  c_float P_x[4] = { 4.0, 1.0, 1.0, 2.0, };
-  c_int   P_nnz  = 4;
-  c_int   P_i[4] = { 0, 1, 0, 1, };
-  c_int   P_p[3] = { 0, 2, 4, };
+  c_float P_x[3] = { 4.0, 1.0, 2.0, };
+  c_int   P_nnz  = 3;
+  c_int   P_i[3] = { 0, 0, 1, };
+  c_int   P_p[3] = { 0, 1, 3, };
   c_float q[2]   = { 1.0, 1.0, };
   c_float A_x[4] = { 1.0, 1.0, 1.0, 1.0, };
   c_int   A_nnz  = 4;

--- a/include/glob_opts.h
+++ b/include/glob_opts.h
@@ -42,7 +42,6 @@ static void* c_realloc(void *ptr, size_t size) {
 
     #   define c_free mxFree
 #  elif defined PYTHON
-
 // Define memory allocation for python. Note that in Python 2 memory manager
 // Calloc is not implemented
     #   include <Python.h>
@@ -52,21 +51,13 @@ static void* c_realloc(void *ptr, size_t size) {
     #   else  /* if PY_MAJOR_VERSION >= 3 */
 static void* c_calloc(size_t num, size_t size) {
   void *m = PyMem_Malloc(num * size);
-
   memset(m, 0, num * size);
   return m;
 }
-
     #   endif /* if PY_MAJOR_VERSION >= 3 */
-
-// #define c_calloc(n,s) ({
-//         void * p_calloc = c_malloc((n)*(s));
-//         memset(p_calloc, 0, (n)*(s));
-//         p_calloc;
-//     })
     #   define c_free PyMem_Free
     #   define c_realloc PyMem_Realloc
-#  else  /* ifdef MATLAB */
+#  else  /* otherwise use standard linux functions */
 
     #   define c_malloc  OSQP_MALLOC
     #   define c_calloc  OSQP_CALLOC
@@ -78,7 +69,7 @@ static void* c_calloc(size_t num, size_t size) {
 #  include <stdlib.h>
 
 
-# endif // end EMBEDDED
+# endif // end ifndef EMBEDDED
 
 
 /* Use customized number representation -----------------------------------   */

--- a/include/glob_opts.h
+++ b/include/glob_opts.h
@@ -28,14 +28,12 @@ static void* c_calloc(size_t num, size_t size) {
 
 static void* c_malloc(size_t size) {
   void *m = mxMalloc(size);
-
   mexMakeMemoryPersistent(m);
   return m;
 }
 
 static void* c_realloc(void *ptr, size_t size) {
   void *m = mxRealloc(ptr, size);
-
   mexMakeMemoryPersistent(m);
   return m;
 }
@@ -57,13 +55,15 @@ static void* c_calloc(size_t num, size_t size) {
     #   endif /* if PY_MAJOR_VERSION >= 3 */
     #   define c_free PyMem_Free
     #   define c_realloc PyMem_Realloc
-#  else  /* otherwise use standard linux functions */
 
-    #   define c_malloc  OSQP_MALLOC
-    #   define c_calloc  OSQP_CALLOC
-    #   define c_free    OSQP_FREE
-    #   define c_realloc OSQP_REALLOC
-
+# elif !defined OSQP_CUSTOM_MEMORY_H
+/* If no custom memory allocator defined, use
+ * standard linux functions. Custom memory allocator definitions
+ * appear in the osqp_configure.h generated file. */
+    #   define c_malloc  malloc
+    #   define c_calloc  calloc
+    #   define c_free    free
+    #   define c_realloc realloc
 #  endif /* ifdef MATLAB */
 
 #  include <stdlib.h>

--- a/include/glob_opts.h
+++ b/include/glob_opts.h
@@ -67,10 +67,11 @@ static void* c_calloc(size_t num, size_t size) {
     #   define c_free PyMem_Free
     #   define c_realloc PyMem_Realloc
 #  else  /* ifdef MATLAB */
-    #   define c_malloc malloc
-    #   define c_calloc calloc
-    #   define c_free free
-    #   define c_realloc realloc
+
+    #   define c_malloc  OSQP_MALLOC
+    #   define c_calloc  OSQP_CALLOC
+    #   define c_free    OSQP_FREE
+    #   define c_realloc OSQP_REALLOC
 
 #  endif /* ifdef MATLAB */
 

--- a/include/glob_opts.h
+++ b/include/glob_opts.h
@@ -56,7 +56,7 @@ static void* c_calloc(size_t num, size_t size) {
     #   define c_free PyMem_Free
     #   define c_realloc PyMem_Realloc
 
-# elif !defined OSQP_CUSTOM_MEMORY_H
+# elif !defined OSQP_CUSTOM_MEMORY
 /* If no custom memory allocator defined, use
  * standard linux functions. Custom memory allocator definitions
  * appear in the osqp_configure.h generated file. */

--- a/include/glob_opts.h
+++ b/include/glob_opts.h
@@ -60,14 +60,12 @@ static void* c_calloc(size_t num, size_t size) {
 /* If no custom memory allocator defined, use
  * standard linux functions. Custom memory allocator definitions
  * appear in the osqp_configure.h generated file. */
-    #   define c_malloc  malloc
-    #   define c_calloc  calloc
-    #   define c_free    free
-    #   define c_realloc realloc
+    #  include <stdlib.h>
+    #  define c_malloc  malloc
+    #  define c_calloc  calloc
+    #  define c_free    free
+    #  define c_realloc realloc
 #  endif /* ifdef MATLAB */
-
-#  include <stdlib.h>
-
 
 # endif // end ifndef EMBEDDED
 

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -67,8 +67,8 @@ c_int adapt_rho(OSQPWorkspace *work) {
   work->info->rho_estimate = rho_new;
 
   // Check if the new rho is large or small enough and update it in case
-  if ((rho_new > work->settings->rho * ADAPTIVE_RHO_TOLERANCE) ||
-      (rho_new < work->settings->rho /  ADAPTIVE_RHO_TOLERANCE)) {
+  if ((rho_new > work->settings->rho * work->settings->adaptive_rho_tolerance) ||
+      (rho_new < work->settings->rho /  work->settings->adaptive_rho_tolerance)) {
     exitflag                 = osqp_update_rho(work, rho_new);
     work->info->rho_updates += 1;
   }

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -247,6 +247,7 @@ c_int osqp_setup(OSQPWorkspace** workp, const OSQPData *data, const OSQPSettings
 # endif /* ifdef PRINTING */
 
 
+
 # if EMBEDDED != 1
 
   // If adaptive rho and automatic interval, but profiling disabled, we need to
@@ -275,6 +276,7 @@ c_int osqp_setup(OSQPWorkspace** workp, const OSQPData *data, const OSQPSettings
 
 
 c_int osqp_solve(OSQPWorkspace *work) {
+
   c_int exitflag;
   c_int iter;
   c_int compute_cost_function; // Boolean whether to compute the cost function
@@ -402,15 +404,11 @@ c_int osqp_solve(OSQPWorkspace *work) {
 #endif /* ifdef PROFILING */
 
 
-    c_print("DEBUG: before check termination\n");
-
     // Can we check for termination ?
     can_check_termination = work->settings->check_termination &&
                             (iter % work->settings->check_termination == 0);
 
 #ifdef PRINTING
-
-    c_print("DEBUG: before can print\n");
 
     // Can we print ?
     can_print = work->settings->verbose &&
@@ -448,8 +446,6 @@ c_int osqp_solve(OSQPWorkspace *work) {
     }
 #endif /* ifdef PRINTING */
 
-    c_print("DEBUG: after can print and check termination\n");
-    c_print("DEBUG: before adaptive rho interval \n");
 
 #if EMBEDDED != 1
 # ifdef PROFILING
@@ -519,7 +515,6 @@ c_int osqp_solve(OSQPWorkspace *work) {
 
   }        // End of ADMM for loop
 
-  c_print("DEBUG: after main admm loop\n");
 
   // Update information and check termination condition if it hasn't been done
   // during last iteration (max_iter reached or check_termination disabled)

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -21,8 +21,10 @@
 * Main API Functions *
 **********************/
 void osqp_set_default_settings(OSQPSettings *settings) {
-  settings->scaling = SCALING; /* heuristic problem scaling */
 
+  settings->rho           = (c_float)RHO;            /* ADMM step */
+  settings->sigma         = (c_float)SIGMA;          /* ADMM step */
+  settings->scaling = SCALING;                       /* heuristic problem scaling */
 #if EMBEDDED != 1
   settings->adaptive_rho           = ADAPTIVE_RHO;
   settings->adaptive_rho_interval  = ADAPTIVE_RHO_INTERVAL;
@@ -32,8 +34,6 @@ void osqp_set_default_settings(OSQPSettings *settings) {
 # endif /* ifdef PROFILING */
 #endif  /* if EMBEDDED != 1 */
 
-  settings->rho           = (c_float)RHO;            /* ADMM step */
-  settings->sigma         = (c_float)SIGMA;          /* ADMM step */
   settings->max_iter      = MAX_ITER;                /* maximum iterations to
                                                         take */
   settings->eps_abs       = (c_float)EPS_ABS;        /* absolute convergence
@@ -284,6 +284,7 @@ c_int osqp_solve(OSQPWorkspace *work) {
 #ifdef PROFILING
   c_float temp_run_time;       // Temporary variable to store current run time
 #endif /* ifdef PROFILING */
+
 #ifdef PRINTING
   c_int can_print;             // Boolean whether you can print
 #endif /* ifdef PRINTING */
@@ -400,11 +401,16 @@ c_int osqp_solve(OSQPWorkspace *work) {
     }
 #endif /* ifdef PROFILING */
 
+
+    c_print("DEBUG: before check termination\n");
+
     // Can we check for termination ?
     can_check_termination = work->settings->check_termination &&
                             (iter % work->settings->check_termination == 0);
 
 #ifdef PRINTING
+
+    c_print("DEBUG: before can print\n");
 
     // Can we print ?
     can_print = work->settings->verbose &&
@@ -442,6 +448,8 @@ c_int osqp_solve(OSQPWorkspace *work) {
     }
 #endif /* ifdef PRINTING */
 
+    c_print("DEBUG: after can print and check termination\n");
+    c_print("DEBUG: before adaptive rho interval \n");
 
 #if EMBEDDED != 1
 # ifdef PROFILING
@@ -510,6 +518,8 @@ c_int osqp_solve(OSQPWorkspace *work) {
 #endif // EMBEDDED != 1
 
   }        // End of ADMM for loop
+
+  c_print("DEBUG: after main admm loop\n");
 
   // Update information and check termination condition if it hasn't been done
   // during last iteration (max_iter reached or check_termination disabled)

--- a/src/util.c
+++ b/src/util.c
@@ -236,7 +236,7 @@ OSQPSettings* copy_settings(const OSQPSettings *settings) {
   new->adaptive_rho = settings->adaptive_rho;
   new->adaptive_rho_interval = settings->adaptive_rho_interval;
   new->adaptive_rho_tolerance = settings->adaptive_rho_tolerance;
-# ifndef PROFILING
+# ifdef PROFILING
   new->adaptive_rho_fraction = settings->adaptive_rho_fraction;
 # endif
 # endif // EMBEDDED != 1

--- a/tests/basic_qp/test_basic_qp.h
+++ b/tests/basic_qp/test_basic_qp.h
@@ -40,68 +40,68 @@ static const char* test_basic_qp_solve()
   // Solve Problem
   osqp_solve(work);
 
-  // Compare solver statuses
-  mu_assert("Basic QP test solve: Error in solver status!",
-            work->info->status_val == sols_data->status_test);
-
-  // Compare primal solutions
-  mu_assert("Basic QP test solve: Error in primal solution!",
-            vec_norm_inf_diff(work->solution->x, sols_data->x_test,
-                              data->n) < TESTS_TOL);
-
-  // Compare dual solutions
-  mu_assert("Basic QP test solve: Error in dual solution!",
-            vec_norm_inf_diff(work->solution->y, sols_data->y_test,
-                              data->m) < TESTS_TOL);
-
-
-  // Compare objective values
-  mu_assert("Basic QP test solve: Error in objective value!",
-            c_absval(work->info->obj_val - sols_data->obj_value_test) <
-            TESTS_TOL);
-
-  // Try to set wrong settings
-  mu_assert("Basic QP test solve: Wrong value of rho not caught!",
-            osqp_update_rho(work, -0.1) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of max_iter not caught!",
-            osqp_update_max_iter(work, -1) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of eps_abs not caught!",
-            osqp_update_eps_abs(work, -1.) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of eps_rel not caught!",
-            osqp_update_eps_rel(work, -1.) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of eps_prim_inf not caught!",
-            osqp_update_eps_prim_inf(work, -0.1) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of eps_dual_inf not caught!",
-            osqp_update_eps_dual_inf(work, -0.1) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of alpha not caught!",
-            osqp_update_alpha(work, 2.0) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of warm_start not caught!",
-            osqp_update_warm_start(work, -1) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of scaled_termination not caught!",
-            osqp_update_scaled_termination(work, 2) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of check_termination not caught!",
-            osqp_update_check_termination(work, -1) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of delta not caught!",
-            osqp_update_delta(work, 0.) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of polish not caught!",
-            osqp_update_polish(work, 2) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of polish_refine_iter not caught!",
-            osqp_update_polish_refine_iter(work, -1) == 1);
-
-  mu_assert("Basic QP test solve: Wrong value of verbose not caught!",
-            osqp_update_verbose(work, 2) == 1);
+  // // Compare solver statuses
+  // mu_assert("Basic QP test solve: Error in solver status!",
+  //           work->info->status_val == sols_data->status_test);
+  //
+  // // Compare primal solutions
+  // mu_assert("Basic QP test solve: Error in primal solution!",
+  //           vec_norm_inf_diff(work->solution->x, sols_data->x_test,
+  //                             data->n) < TESTS_TOL);
+  //
+  // // Compare dual solutions
+  // mu_assert("Basic QP test solve: Error in dual solution!",
+  //           vec_norm_inf_diff(work->solution->y, sols_data->y_test,
+  //                             data->m) < TESTS_TOL);
+  //
+  //
+  // // Compare objective values
+  // mu_assert("Basic QP test solve: Error in objective value!",
+  //           c_absval(work->info->obj_val - sols_data->obj_value_test) <
+  //           TESTS_TOL);
+  //
+  // // Try to set wrong settings
+  // mu_assert("Basic QP test solve: Wrong value of rho not caught!",
+  //           osqp_update_rho(work, -0.1) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of max_iter not caught!",
+  //           osqp_update_max_iter(work, -1) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of eps_abs not caught!",
+  //           osqp_update_eps_abs(work, -1.) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of eps_rel not caught!",
+  //           osqp_update_eps_rel(work, -1.) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of eps_prim_inf not caught!",
+  //           osqp_update_eps_prim_inf(work, -0.1) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of eps_dual_inf not caught!",
+  //           osqp_update_eps_dual_inf(work, -0.1) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of alpha not caught!",
+  //           osqp_update_alpha(work, 2.0) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of warm_start not caught!",
+  //           osqp_update_warm_start(work, -1) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of scaled_termination not caught!",
+  //           osqp_update_scaled_termination(work, 2) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of check_termination not caught!",
+  //           osqp_update_check_termination(work, -1) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of delta not caught!",
+  //           osqp_update_delta(work, 0.) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of polish not caught!",
+  //           osqp_update_polish(work, 2) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of polish_refine_iter not caught!",
+  //           osqp_update_polish_refine_iter(work, -1) == 1);
+  //
+  // mu_assert("Basic QP test solve: Wrong value of verbose not caught!",
+  //           osqp_update_verbose(work, 2) == 1);
 
 
   // Clean workspace
@@ -539,7 +539,7 @@ static const char* test_basic_qp_time_limit()
 
   // Compare solver statuses
   mu_assert("Basic QP test time limit: Error in no time limit solver status!",
-            work->info->status_val == sols_data->status_test);
+	    work->info->status_val == sols_data->status_test);
 
   // Update time limit
   osqp_update_time_limit(work, 1e-5);
@@ -551,7 +551,7 @@ static const char* test_basic_qp_time_limit()
 
   // Compare solver statuses
   mu_assert("Time limit test: Error in timed out solver status!",
-            work->info->status_val == OSQP_TIME_LIMIT_REACHED);
+	    work->info->status_val == OSQP_TIME_LIMIT_REACHED);
 
   // Cleanup solver
   osqp_cleanup(work);
@@ -569,13 +569,13 @@ static const char* test_basic_qp_time_limit()
 static const char* test_basic_qp()
 {
   mu_run_test(test_basic_qp_solve);
-#ifdef ENABLE_MKL_PARDISO
-  mu_run_test(test_basic_qp_solve_pardiso);
-#endif
-  mu_run_test(test_basic_qp_update);
-  mu_run_test(test_basic_qp_check_termination);
-  mu_run_test(test_basic_qp_update_rho);
-  mu_run_test(test_basic_qp_time_limit);
+// #ifdef ENABLE_MKL_PARDISO
+//   mu_run_test(test_basic_qp_solve_pardiso);
+// #endif
+//   mu_run_test(test_basic_qp_update);
+//   mu_run_test(test_basic_qp_check_termination);
+//   mu_run_test(test_basic_qp_update_rho);
+//   mu_run_test(test_basic_qp_time_limit);
 
   return 0;
 }

--- a/tests/basic_qp/test_basic_qp.h
+++ b/tests/basic_qp/test_basic_qp.h
@@ -37,72 +37,73 @@ static const char* test_basic_qp_solve()
   // Setup correct
   mu_assert("Basic QP test solve: Setup error!", exitflag == 0);
 
+
   // Solve Problem
   osqp_solve(work);
 
-  // // Compare solver statuses
-  // mu_assert("Basic QP test solve: Error in solver status!",
-  //           work->info->status_val == sols_data->status_test);
-  //
-  // // Compare primal solutions
-  // mu_assert("Basic QP test solve: Error in primal solution!",
-  //           vec_norm_inf_diff(work->solution->x, sols_data->x_test,
-  //                             data->n) < TESTS_TOL);
-  //
-  // // Compare dual solutions
-  // mu_assert("Basic QP test solve: Error in dual solution!",
-  //           vec_norm_inf_diff(work->solution->y, sols_data->y_test,
-  //                             data->m) < TESTS_TOL);
-  //
-  //
-  // // Compare objective values
-  // mu_assert("Basic QP test solve: Error in objective value!",
-  //           c_absval(work->info->obj_val - sols_data->obj_value_test) <
-  //           TESTS_TOL);
-  //
-  // // Try to set wrong settings
-  // mu_assert("Basic QP test solve: Wrong value of rho not caught!",
-  //           osqp_update_rho(work, -0.1) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of max_iter not caught!",
-  //           osqp_update_max_iter(work, -1) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of eps_abs not caught!",
-  //           osqp_update_eps_abs(work, -1.) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of eps_rel not caught!",
-  //           osqp_update_eps_rel(work, -1.) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of eps_prim_inf not caught!",
-  //           osqp_update_eps_prim_inf(work, -0.1) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of eps_dual_inf not caught!",
-  //           osqp_update_eps_dual_inf(work, -0.1) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of alpha not caught!",
-  //           osqp_update_alpha(work, 2.0) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of warm_start not caught!",
-  //           osqp_update_warm_start(work, -1) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of scaled_termination not caught!",
-  //           osqp_update_scaled_termination(work, 2) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of check_termination not caught!",
-  //           osqp_update_check_termination(work, -1) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of delta not caught!",
-  //           osqp_update_delta(work, 0.) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of polish not caught!",
-  //           osqp_update_polish(work, 2) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of polish_refine_iter not caught!",
-  //           osqp_update_polish_refine_iter(work, -1) == 1);
-  //
-  // mu_assert("Basic QP test solve: Wrong value of verbose not caught!",
-  //           osqp_update_verbose(work, 2) == 1);
+  // Compare solver statuses
+  mu_assert("Basic QP test solve: Error in solver status!",
+	    work->info->status_val == sols_data->status_test);
 
+  // Compare primal solutions
+  mu_assert("Basic QP test solve: Error in primal solution!",
+	    vec_norm_inf_diff(work->solution->x, sols_data->x_test,
+			      data->n) < TESTS_TOL);
+
+  // Compare dual solutions
+  mu_assert("Basic QP test solve: Error in dual solution!",
+	    vec_norm_inf_diff(work->solution->y, sols_data->y_test,
+			      data->m) < TESTS_TOL);
+
+
+  // Compare objective values
+  mu_assert("Basic QP test solve: Error in objective value!",
+	    c_absval(work->info->obj_val - sols_data->obj_value_test) <
+	    TESTS_TOL);
+
+  // Try to set wrong settings
+  mu_assert("Basic QP test solve: Wrong value of rho not caught!",
+	    osqp_update_rho(work, -0.1) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of max_iter not caught!",
+	    osqp_update_max_iter(work, -1) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of eps_abs not caught!",
+	    osqp_update_eps_abs(work, -1.) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of eps_rel not caught!",
+	    osqp_update_eps_rel(work, -1.) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of eps_prim_inf not caught!",
+	    osqp_update_eps_prim_inf(work, -0.1) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of eps_dual_inf not caught!",
+	    osqp_update_eps_dual_inf(work, -0.1) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of alpha not caught!",
+	    osqp_update_alpha(work, 2.0) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of warm_start not caught!",
+	    osqp_update_warm_start(work, -1) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of scaled_termination not caught!",
+	    osqp_update_scaled_termination(work, 2) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of check_termination not caught!",
+	    osqp_update_check_termination(work, -1) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of delta not caught!",
+	    osqp_update_delta(work, 0.) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of polish not caught!",
+	    osqp_update_polish(work, 2) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of polish_refine_iter not caught!",
+	    osqp_update_polish_refine_iter(work, -1) == 1);
+
+  mu_assert("Basic QP test solve: Wrong value of verbose not caught!",
+	    osqp_update_verbose(work, 2) == 1);
+//
 
   // Clean workspace
   osqp_cleanup(work);
@@ -569,13 +570,13 @@ static const char* test_basic_qp_time_limit()
 static const char* test_basic_qp()
 {
   mu_run_test(test_basic_qp_solve);
-// #ifdef ENABLE_MKL_PARDISO
-//   mu_run_test(test_basic_qp_solve_pardiso);
-// #endif
-//   mu_run_test(test_basic_qp_update);
-//   mu_run_test(test_basic_qp_check_termination);
-//   mu_run_test(test_basic_qp_update_rho);
-//   mu_run_test(test_basic_qp_time_limit);
+#ifdef ENABLE_MKL_PARDISO
+  mu_run_test(test_basic_qp_solve_pardiso);
+#endif
+  mu_run_test(test_basic_qp_update);
+  mu_run_test(test_basic_qp_check_termination);
+  mu_run_test(test_basic_qp_update_rho);
+  mu_run_test(test_basic_qp_time_limit);
 
   return 0;
 }

--- a/tests/custom_memory/custom_memory.c
+++ b/tests/custom_memory/custom_memory.c
@@ -27,7 +27,9 @@ void* my_realloc(void *ptr, size_t size) {
 }
 
 void my_free(void *ptr) {
-  free(ptr);
-  alloc_counter--;
-  printf("OSQP allocator   (free) : %ld allocations \n", alloc_counter);
+  if(ptr != NULL){
+    free(ptr);
+    alloc_counter--;
+    printf("OSQP allocator   (free) : %ld allocations \n", alloc_counter);
+  }
 }

--- a/tests/custom_memory/custom_memory.c
+++ b/tests/custom_memory/custom_memory.c
@@ -1,0 +1,33 @@
+#  include "custom_memory.h"
+#  include <stdlib.h>
+#  include <stdio.h>
+
+//Make a global counter and track the net number of allocations
+//by user defined allocators.   Should go to zero on exit if no leaks.
+long int alloc_counter = 0;
+
+void* my_malloc(size_t size) {
+  void *m = malloc(size);
+  alloc_counter++;
+  printf("OSQP allocator  (malloc): %zu bytes, %ld allocations \n",size, alloc_counter);
+  return m;
+}
+
+void* my_calloc(size_t num, size_t size) {
+  void *m = calloc(num, size);
+  alloc_counter++;
+  printf("OSQP allocator  (calloc): %zu bytes, %ld allocations \n",num*size, alloc_counter);
+  return m;
+}
+
+void* my_realloc(void *ptr, size_t size) {
+  void *m = realloc(ptr,size);
+  printf("OSQP allocator (realloc) : %zu bytes, %ld allocations \n",size, alloc_counter);
+  return m;
+}
+
+void my_free(void *ptr) {
+  free(ptr);
+  alloc_counter--;
+  printf("OSQP allocator   (free) : %ld allocations \n", alloc_counter);
+}

--- a/tests/custom_memory/custom_memory.h
+++ b/tests/custom_memory/custom_memory.h
@@ -1,5 +1,51 @@
+#ifndef OSQP_CUSTOM_MEMORY_H
+#define OSQP_CUSTOM_MEMORY_H
+
+# ifdef __cplusplus
+extern "C" {
+# endif /* ifdef __cplusplus */
+
+
 #  include <stdlib.h>
-#  define c_malloc  malloc
-#  define c_calloc  calloc
-#  define c_free    free
-#  define c_realloc realloc
+#  include <stdio.h>
+
+#  define c_malloc  my_malloc
+#  define c_calloc  my_calloc
+#  define c_free    my_free
+#  define c_realloc my_realloc
+
+//Make a global counter and track the net number of allocations
+//by user defined allocators.   Should go to zero on exit if no leaks.
+static long int alloc_counter = 0;
+
+static void* my_malloc(size_t size) {
+  void *m = malloc(size);
+  alloc_counter++;
+  printf("OSQP allocator  (malloc): %zu bytes, %ld allocations \n",size, alloc_counter);
+  return m;
+}
+
+static void* my_calloc(size_t num, size_t size) {
+  void *m = calloc(num, size);
+  alloc_counter++;
+  printf("OSQP allocator  (calloc): %zu bytes, %ld allocations \n",num*size, alloc_counter);
+  return m;
+}
+
+static void* my_realloc(void *ptr, size_t size) {
+  void *m = realloc(ptr,size);
+  printf("OSQP allocator (realloc) : %zu bytes, %ld allocations \n",size, alloc_counter);
+  return m;
+}
+
+static void my_free(void *ptr) {
+  free(ptr);
+  alloc_counter--;
+  printf("OSQP allocator   (free) : %ld allocations \n", alloc_counter);
+}
+
+# ifdef __cplusplus
+}
+# endif /* ifdef __cplusplus */
+
+#endif /* ifndef  OSQP_CUSTOM_MEMORY_H */

--- a/tests/custom_memory/custom_memory.h
+++ b/tests/custom_memory/custom_memory.h
@@ -1,0 +1,5 @@
+#  include <stdlib.h>
+#  define c_malloc  malloc
+#  define c_calloc  calloc
+#  define c_free    free
+#  define c_realloc realloc

--- a/tests/custom_memory/custom_memory.h
+++ b/tests/custom_memory/custom_memory.h
@@ -1,48 +1,24 @@
 #ifndef OSQP_CUSTOM_MEMORY_H
+
 #define OSQP_CUSTOM_MEMORY_H
 
 # ifdef __cplusplus
 extern "C" {
 # endif /* ifdef __cplusplus */
 
-
-#  include <stdlib.h>
-#  include <stdio.h>
+#  include <stdio.h> //for size_t
 
 #  define c_malloc  my_malloc
 #  define c_calloc  my_calloc
 #  define c_free    my_free
 #  define c_realloc my_realloc
 
-//Make a global counter and track the net number of allocations
-//by user defined allocators.   Should go to zero on exit if no leaks.
-static long int alloc_counter = 0;
-
-static void* my_malloc(size_t size) {
-  void *m = malloc(size);
-  alloc_counter++;
-  printf("OSQP allocator  (malloc): %zu bytes, %ld allocations \n",size, alloc_counter);
-  return m;
-}
-
-static void* my_calloc(size_t num, size_t size) {
-  void *m = calloc(num, size);
-  alloc_counter++;
-  printf("OSQP allocator  (calloc): %zu bytes, %ld allocations \n",num*size, alloc_counter);
-  return m;
-}
-
-static void* my_realloc(void *ptr, size_t size) {
-  void *m = realloc(ptr,size);
-  printf("OSQP allocator (realloc) : %zu bytes, %ld allocations \n",size, alloc_counter);
-  return m;
-}
-
-static void my_free(void *ptr) {
-  free(ptr);
-  alloc_counter--;
-  printf("OSQP allocator   (free) : %ld allocations \n", alloc_counter);
-}
+/* functions should have the same
+signatures as the standard ones */
+void* my_malloc(size_t size);
+void* my_calloc(size_t num, size_t size);
+void* my_realloc(void *ptr, size_t size);
+void  my_free(void *ptr);
 
 # ifdef __cplusplus
 }

--- a/tests/osqp_tester.c
+++ b/tests/osqp_tester.c
@@ -25,15 +25,15 @@ int tests_run = 0;
 
 
 static const char* all_tests() {
-  mu_run_test(test_lin_alg);
-  mu_run_test(test_solve_linsys);
+  // mu_run_test(test_lin_alg);
+  // mu_run_test(test_solve_linsys);
   mu_run_test(test_basic_qp);
-  mu_run_test(test_basic_qp2);
-  mu_run_test(test_non_cvx);
-  mu_run_test(test_primal_infeasibility);
-  mu_run_test(test_primal_dual_infeasibility);
-  mu_run_test(test_unconstrained);
-  mu_run_test(test_update_matrices);
+  // mu_run_test(test_basic_qp2);
+  // mu_run_test(test_non_cvx);
+  // mu_run_test(test_primal_infeasibility);
+  // mu_run_test(test_primal_dual_infeasibility);
+  // mu_run_test(test_unconstrained);
+  // mu_run_test(test_update_matrices);
   return 0;
 }
 

--- a/tests/osqp_tester.c
+++ b/tests/osqp_tester.c
@@ -25,15 +25,15 @@ int tests_run = 0;
 
 
 static const char* all_tests() {
-  // mu_run_test(test_lin_alg);
-  // mu_run_test(test_solve_linsys);
+  mu_run_test(test_lin_alg);
+  mu_run_test(test_solve_linsys);
   mu_run_test(test_basic_qp);
-  // mu_run_test(test_basic_qp2);
-  // mu_run_test(test_non_cvx);
-  // mu_run_test(test_primal_infeasibility);
-  // mu_run_test(test_primal_dual_infeasibility);
-  // mu_run_test(test_unconstrained);
-  // mu_run_test(test_update_matrices);
+  mu_run_test(test_basic_qp2);
+  mu_run_test(test_non_cvx);
+  mu_run_test(test_primal_infeasibility);
+  mu_run_test(test_primal_dual_infeasibility);
+  mu_run_test(test_unconstrained);
+  mu_run_test(test_update_matrices);
   return 0;
 }
 


### PR DESCRIPTION
This PR adds the possibility to pass custom memory management functions. It can be done by specifying an additional header file where the custom functions are defined (or included) as `-DOSQSP_CUSTOM_MEMORY_H=myfile.h`

The file should have the structure
```c
# include <mycustomem.h>
# define c_malloc  mymalloc
# define c_calloc mycalloc
# define c_realloc as myrealloc
# define c_free myfree 
```

@nikalra does it solve your issue? #136. Feedbacks are welcome.