### PR TITLE
Change interface of linsys solver functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 * Added meaningful return values to internal functions. Changed syntax of `osqp_setup` function. It now returns an exitflag.
 * `osqp_setup` function requires `P` to be upper triangular. It returns a nonzero exitflag otherwise.
 * Custom memory allocators via cmake and the configure file.
+* Changed interfaces to linsys solver functions. The solve function now computes `(x_tilde,z_tilde)` instead of `(x_tilde,nu)`.
 
 
 Version 0.5.0 (10 December 2018)

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -55,10 +55,10 @@ The linear system solver object is defined in :code:`mysolver.h` as follows
             // Methods
             enum linsys_solver_type type; // Linear system solver defined in constants.h
 
-            c_int (*solve)(struct mysolver * self, c_float * b, const OSQPSettings * settings);
+            c_int (*solve)(struct mysolver * self, c_float * b);
             void (*free)(struct mysolver * self);
-            c_int (*update_matrices)(struct mysolver * self, const csc *P, const csc *A, const OSQPSettings *settings);
-            c_int (*update_rho_vec)(struct mysolver * self, const c_float * rho_vec, const c_int m);
+            c_int (*update_matrices)(struct mysolver * self, const csc *P, const csc *A);
+            c_int (*update_rho_vec)(struct mysolver * self, const c_float * rho_vec);
 
             // Attributes
             c_int nthreads; // Number of threads used (required!)
@@ -78,14 +78,13 @@ The linear system solver object is defined in :code:`mysolver.h` as follows
         c_int init_linsys_solver_mysolver(mysolver_solver ** s, const csc * P, const csc * A, c_float sigma, c_float * rho_vec, c_int polish);
 
         // Solve linear system and store result in b
-        c_int solve_linsys_mysolver(mysolver_solver * s, c_float * b, const OSQPSettings * settings);
+        c_int solve_linsys_mysolver(mysolver_solver * s, c_float * b);
 
          // Update linear system solver matrices
-        c_int update_linsys_solver_matrices_mysolver(mysolver_solver * s,
-                        const csc *P, const csc *A, const OSQPSettings *settings);
+        c_int update_linsys_solver_matrices_mysolver(mysolver_solver * s, const csc *P, const csc *A);
 
-        // Update rho parameter in linear system solver structure
-        c_int update_linsys_solver_rho_vec_mysolver(mysolver_solver * s, const c_float * rho_vec, const c_int m);
+        // Update rho_vec parameter in linear system solver structure
+        c_int update_linsys_solver_rho_vec_mysolver(mysolver_solver * s, const c_float * rho_vec);
 
         // Free linear system solver
         void free_linsys_solver_mysolver(mysolver_solver * s);

--- a/docs/get_started/julia.rst
+++ b/docs/get_started/julia.rst
@@ -5,7 +5,7 @@ Julia interface can be directly installed from Julia package manager by running
 
 .. code:: julia
 
-   Pkg.add("OSQP")
+   ] add OSQP
 
 
 The interface code is available on `GitHub <https://github.com/oxfordcontrol/OSQP.jl>`_.

--- a/docs/get_started/linear_system_solvers.rst
+++ b/docs/get_started/linear_system_solvers.rst
@@ -60,18 +60,10 @@ where :code:`MKLROOT` is the MKL installation directory.
 Install with Anaconda
 ^^^^^^^^^^^^^^^^^^^^^
 `Anaconda Python distribution <https://www.anaconda.com/download/>`_ comes with the intel MKL libraries preinstalled including MKL Pardiso.
-To use this version, the Anaconda libraries folders have to be added to the system path.
-In particular, given the Anaconda installation directory :code:`ANACONDA_ROOT`, we need to add the following folders:
+To use this version, the Anaconda libraries folders have to be in your system path.
+Anaconda environments should add them automatically so in most cases you do not have do to anything. If you get an error where OSQP cannot find MKL, you can add the right path by adding the output from the following command to your path:
 
-* :code:`libmkl_rt`: This library is located in the folder :code:`ANACONDA_ROOT/pkgs/mkl-VERSION/lib` where :code:`VERSION` is the version of the :code:`mkl` package.
+.. code::
 
-* :code:`libiomp`: This library is located in the folder :code:`ANACONDA_ROOT/pkgs/intel-openmp-VERSION/lib` where :code:`VERSION` is the version of the :code:`intel-openmp` package.
-
-
-
-
-
-
-
-
+   python -c 'import numpy.distutils.system_info as sysinfo; print(sysinfo.get_info("mkl")["library_dirs"][0])'
 

--- a/include/types.h
+++ b/include/types.h
@@ -313,11 +313,10 @@ typedef struct {
  *      on the choice
  */
 struct linsys_solver {
-  enum linsys_solver_type type; ///< Linear system solver type
+  enum linsys_solver_type type;                 ///< Linear system solver type
   // Functions
-  c_int (*solve)(LinSysSolver       *self,
-                 c_float            *b,
-                 const OSQPSettings *settings); ///< Solve linear system
+  c_int (*solve)(LinSysSolver *self,
+                 c_float      *b);              ///< Solve linear system
 
 # ifndef EMBEDDED
   void (*free)(LinSysSolver *self);             ///< Free linear system solver
@@ -325,12 +324,12 @@ struct linsys_solver {
 # endif // ifndef EMBEDDED
 
 # if EMBEDDED != 1
-  c_int (*update_matrices)(LinSysSolver *self, const csc *P, const csc *A,
-                           const OSQPSettings *settings); ///< Update matrices P
-                                                          // and A in the solver
+  c_int (*update_matrices)(LinSysSolver *s,
+                           const csc *P,            ///< Update matrices P
+                           const csc *A);           //   and A in the solver
+
   c_int (*update_rho_vec)(LinSysSolver  *s,
-                          const c_float *rho_vec,
-                          const c_int    m);              ///< Update rho
+                          const c_float *rho_vec);  ///< Update rho_vec
 # endif // if EMBEDDED != 1
 
 # ifndef EMBEDDED

--- a/lin_sys/direct/pardiso/pardiso_interface.c
+++ b/lin_sys/direct/pardiso/pardiso_interface.c
@@ -40,13 +40,8 @@ void free_linsys_solver_pardiso(pardiso_solver *s) {
 
         // Free pardiso solver using internal function
         s->phase = PARDISO_CLEANUP;
-        // c_print("s->mnum: %f", s->mnum);
-        // c_print("s->mtype: %f", s->mtype);
-        // c_print("s->phase: %f", s->phase);
-        // c_print("s->n: %f", s->n);
-        // c_print("s->fdum: %f", s->fdum);
         pardiso (s->pt, &(s->maxfct), &(s->mnum), &(s->mtype), &(s->phase),
-                 &(s->n), &(s->fdum), s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
+                 &(s->nKKT), &(s->fdum), s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
                  s->iparm, &(s->msglvl), &(s->fdum), &(s->fdum), &(s->error));
 
       if ( s->error != 0 ){
@@ -55,10 +50,14 @@ void free_linsys_solver_pardiso(pardiso_solver *s) {
 #endif
       }
         // Check each attribute of the structure and free it if it exists
-        if (s->KKT)       csc_spfree(s->KKT);
-        if (s->KKT_i)     c_free(s->KKT_i);
-        if (s->KKT_p)     c_free(s->KKT_p);
-        if (s->bp)        c_free(s->bp);
+        if (s->KKT)         csc_spfree(s->KKT);
+        if (s->KKT_i)       c_free(s->KKT_i);
+        if (s->KKT_p)       c_free(s->KKT_p);
+        if (s->bp)          c_free(s->bp);
+        if (s->sol)         c_free(s->sol);
+        if (s->rho_inv_vec) c_free(s->rho_inv_vec);
+
+        // These are required for matrix updates
         if (s->Pdiag_idx) c_free(s->Pdiag_idx);
         if (s->PtoKKT)    c_free(s->PtoKKT);
         if (s->AtoKKT)    c_free(s->AtoKKT);
@@ -77,14 +76,23 @@ c_int init_linsys_solver_pardiso(pardiso_solver ** sp, const csc * P, const csc 
     // Define Variables
     c_int n_plus_m;              // n_plus_m dimension
 
-    // Size of KKT
-    n_plus_m = P->m + A->m;
 
     // Allocate private structure to store KKT factorization
     pardiso_solver *s;
     s = c_calloc(1, sizeof(pardiso_solver));
     *sp = s;
-    s->n = n_plus_m;
+
+    // Size of KKT
+    s->n = P->n;
+    s->m = A->m;
+    n_plus_m = s->n + s->m;
+    s->nKKT = n_plus_m;
+
+    // Sigma parameter
+    s->sigma = sigma;
+
+    // Polishing flag
+    s->polish = polish;
 
     // Link Functions
     s->solve = &solve_linsys_pardiso;
@@ -96,16 +104,22 @@ c_int init_linsys_solver_pardiso(pardiso_solver ** sp, const csc * P, const csc 
     s->type = MKL_PARDISO_SOLVER;
 
     // Working vector
-    s->bp = c_malloc(sizeof(c_float) * n_plus_m);
+    s->bp = (c_float *)c_malloc(sizeof(c_float) * n_plus_m);
+
+    // Solution vector
+    s->sol  = (c_float *)c_malloc(sizeof(c_float) * n_plus_m);
+
+    // Parameter vector
+    s->rho_inv_vec = (c_float *)c_malloc(sizeof(c_float) * n_plus_m);
 
     // Form KKT matrix
     if (polish){ // Called from polish()
-        // Use s->bp for storing param2 = vec(delta)
+        // Use s->rho_inv_vec for storing param2 = vec(delta)
         for (i = 0; i < A->m; i++){
-            s->bp[i] = sigma;
+            s->rho_inv_vec[i] = sigma;
         }
 
-        s->KKT = form_KKT(P, A, 1, sigma, s->bp, OSQP_NULL, OSQP_NULL, OSQP_NULL, OSQP_NULL, OSQP_NULL);
+        s->KKT = form_KKT(P, A, 1, sigma, s->rho_inv_vec, OSQP_NULL, OSQP_NULL, OSQP_NULL, OSQP_NULL, OSQP_NULL);
     }
     else { // Called from ADMM algorithm
 
@@ -114,12 +128,12 @@ c_int init_linsys_solver_pardiso(pardiso_solver ** sp, const csc * P, const csc 
         s->AtoKKT = c_malloc((A->p[A->n]) * sizeof(c_int));
         s->rhotoKKT = c_malloc((A->m) * sizeof(c_int));
 
-        // Use s->bp for storing param2 = rho_inv_vec
+        // Use s->rho_inv_vec for storing param2 = rho_inv_vec
         for (i = 0; i < A->m; i++){
-            s->bp[i] = 1. / rho_vec[i];
+            s->rho_inv_vec[i] = 1. / rho_vec[i];
         }
 
-        s->KKT = form_KKT(P, A, 1, sigma, s->bp,
+        s->KKT = form_KKT(P, A, 1, sigma, s->rho_inv_vec,
                              s->PtoKKT, s->AtoKKT,
                              &(s->Pdiag_idx), &(s->Pdiag_n), s->rhotoKKT);
     }
@@ -160,13 +174,17 @@ c_int init_linsys_solver_pardiso(pardiso_solver ** sp, const csc * P, const csc 
     s->mnum = 1;          // Which factorization to use
     s->msglvl = 0;        // Do not print statistical information
     s->error = 0;         // Initialize error flag
-    for ( i = 0; i < 64; i++ ){
+    for ( i = 0; i < 64; i++ ) {
         s->iparm[i] = 0;  // Setup Pardiso control parameters
         s->pt[i] = 0;     // Initialize the internal solver memory pointer
     }
     s->iparm[0] = 1;      // No solver default
     s->iparm[1] = 3;      // Fill-in reordering from OpenMP
-    s->iparm[5] = 1;      // Write solution into b
+    if (polish) {
+        s->iparm[5] = 1;  // Write solution into b
+    } else {
+        s->iparm[5] = 0;  // Do NOT write solution into b
+    }
     /* s->iparm[7] = 2;      // Max number of iterative refinement steps */
     s->iparm[7] = 0;      // Number of iterative refinement steps (auto, performs them only if perturbed pivots are obtained)
     s->iparm[9] = 13;     // Perturb the pivot elements with 1E-13
@@ -179,7 +197,7 @@ c_int init_linsys_solver_pardiso(pardiso_solver ** sp, const csc * P, const csc 
     // Reordering and symbolic factorization
     s->phase = PARDISO_SYMBOLIC;
     pardiso (s->pt, &(s->maxfct), &(s->mnum), &(s->mtype), &(s->phase),
-             &(s->n), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
+             &(s->nKKT), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
              s->iparm, &(s->msglvl), &(s->fdum), &(s->fdum), &(s->error));
     if ( s->error != 0 ){
 #ifdef PRINTING
@@ -193,7 +211,7 @@ c_int init_linsys_solver_pardiso(pardiso_solver ** sp, const csc * P, const csc 
     // Numerical factorization
     s->phase = PARDISO_NUMERIC;
     pardiso (s->pt, &(s->maxfct), &(s->mnum), &(s->mtype), &(s->phase),
-             &(s->n), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
+             &(s->nKKT), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
              s->iparm, &(s->msglvl), &(s->fdum), &(s->fdum), &(s->error));
     if ( s->error ){
 #ifdef PRINTING
@@ -210,12 +228,14 @@ c_int init_linsys_solver_pardiso(pardiso_solver ** sp, const csc * P, const csc 
 }
 
 // Returns solution to linear system  Ax = b with solution stored in b
-c_int solve_linsys_pardiso(pardiso_solver * s, c_float * b, const OSQPSettings *settings) {
+c_int solve_linsys_pardiso(pardiso_solver * s, c_float * b) {
+    c_int j;
+
     // Back substitution and iterative refinement
     s->phase = PARDISO_SOLVE;
     pardiso (s->pt, &(s->maxfct), &(s->mnum), &(s->mtype), &(s->phase),
-             &(s->n), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
-             s->iparm, &(s->msglvl), b, s->bp, &(s->error));
+             &(s->nKKT), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
+             s->iparm, &(s->msglvl), b, s->sol, &(s->error));
     if ( s->error != 0 ){
 #ifdef PRINTING
         c_eprint("Error during linear system solution: %d", (int)s->error);
@@ -223,15 +243,26 @@ c_int solve_linsys_pardiso(pardiso_solver * s, c_float * b, const OSQPSettings *
         return 1;
     }
 
+    if (!(s->polish)) {
+        /* copy x_tilde from s->sol */
+        for (j = 0 ; j < s->n ; j++) {
+            b[j] = s->sol[j];
+        }
+
+        /* compute z_tilde from b and s->sol */
+        for (j = 0 ; j < s->m ; j++) {
+            b[j + s->n] += s->rho_inv_vec[j] * s->sol[j + s->n];
+        }
+    }
+
     return 0;
 }
 
 // Update solver structure with new P and A
-c_int update_linsys_solver_matrices_pardiso(pardiso_solver * s,
-		const csc *P, const csc *A, const OSQPSettings *settings){
+c_int update_linsys_solver_matrices_pardiso(pardiso_solver * s, const csc *P, const csc *A) {
 
     // Update KKT matrix with new P
-    update_KKT_P(s->KKT, P, s->PtoKKT, settings->sigma, s->Pdiag_idx, s->Pdiag_n);
+    update_KKT_P(s->KKT, P, s->PtoKKT, s->sigma, s->Pdiag_idx, s->Pdiag_n);
 
     // Update KKT matrix with new A
     update_KKT_A(s->KKT, A, s->AtoKKT);
@@ -239,7 +270,7 @@ c_int update_linsys_solver_matrices_pardiso(pardiso_solver * s,
     // Perform numerical factorization
     s->phase = PARDISO_NUMERIC;
     pardiso (s->pt, &(s->maxfct), &(s->mnum), &(s->mtype), &(s->phase),
-             &(s->n), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
+             &(s->nKKT), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
              s->iparm, &(s->msglvl), &(s->fdum), &(s->fdum), &(s->error));
 
     // Return exit flag
@@ -247,21 +278,21 @@ c_int update_linsys_solver_matrices_pardiso(pardiso_solver * s,
 }
 
 
-c_int update_linsys_solver_rho_vec_pardiso(pardiso_solver * s, const c_float * rho_vec, const c_int m){
+c_int update_linsys_solver_rho_vec_pardiso(pardiso_solver * s, const c_float * rho_vec) {
     c_int i;
 
-    // Use s->bp for storing param2 = rho_inv_vec
-    for (i = 0; i < m; i++){
-        s->bp[i] = 1. / rho_vec[i];
+    // Update internal rho_inv_vec
+    for (i = 0; i < s->m; i++){
+        s->rho_inv_vec[i] = 1. / rho_vec[i];
     }
 
-    // Update KKT matrix with new rho
-    update_KKT_param2(s->KKT, s->bp, s->rhotoKKT, m);
+    // Update KKT matrix with new rho_vec
+    update_KKT_param2(s->KKT, s->rho_inv_vec, s->rhotoKKT, s->m);
 
     // Perform numerical factorization
     s->phase = PARDISO_NUMERIC;
     pardiso (s->pt, &(s->maxfct), &(s->mnum), &(s->mtype), &(s->phase),
-             &(s->n), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
+             &(s->nKKT), s->KKT->x, s->KKT_p, s->KKT_i, &(s->idum), &(s->nrhs),
              s->iparm, &(s->msglvl), &(s->fdum), &(s->fdum), &(s->error));
 
     // Return exit flag

--- a/lin_sys/direct/pardiso/pardiso_interface.h
+++ b/lin_sys/direct/pardiso/pardiso_interface.h
@@ -22,12 +22,12 @@ struct pardiso {
      * @name Functions
      * @{
      */
-    c_int (*solve)(struct pardiso * self, c_float * b, const OSQPSettings * settings);
+    c_int (*solve)(struct pardiso * self, c_float * b);
 
     void (*free)(struct pardiso * self); ///< Free workspace (only if desktop)
 
-    c_int (*update_matrices)(struct pardiso * self, const csc *P, const csc *A, const OSQPSettings *settings); ///< Update solver matrices
-    c_int (*update_rho_vec)(struct pardiso * self, const c_float * rho_vec, const c_int m); ///< Update solver matrices
+    c_int (*update_matrices)(struct pardiso * self, const csc *P, const csc *A);    ///< Update solver matrices
+    c_int (*update_rho_vec)(struct pardiso * self, const c_float * rho_vec);        ///< Update rho_vec parameter
 
     c_int nthreads;
     /** @} */
@@ -38,15 +38,21 @@ struct pardiso {
      * @{
      */
     // Attributes
-    csc *KKT;         ///< KKT matrix (in CSR format!)
-    c_int *KKT_i;     ///< KKT column indices in 1-indexing for Pardiso
-    c_int *KKT_p;     ///< KKT row pointers in 1-indexing for Pardiso
-    c_float *bp;      ///< workspace memory for solves (rhs)
+    csc *KKT;               ///< KKT matrix (in CSR format!)
+    c_int *KKT_i;           ///< KKT column indices in 1-indexing for Pardiso
+    c_int *KKT_p;           ///< KKT row pointers in 1-indexing for Pardiso
+    c_float *bp;            ///< workspace memory for solves (rhs)
+    c_float *sol;           ///< solution to the KKT system
+    c_float *rho_inv_vec;   ///< parameter vector
+    c_float sigma;          ///< scalar parameter
+    c_int polish;           ///< polishing flag
+    c_int n;                ///< number of QP variables
+    c_int m;                ///< number of QP constraints
 
     // Pardiso variables
     void *pt[64];     ///< internal solver memory pointer pt
     c_int iparm[64];  ///< Pardiso control parameters
-    c_int n;          ///< dimension of the linear system
+    c_int nKKT;       ///< dimension of the linear system
     c_int mtype;      ///< matrix type (-2 for real and symmetric indefinite)
     c_int nrhs;       ///< number of right-hand sides (1 for our needs)
     c_int maxfct;     ///< maximum number of factors (1 for our needs)
@@ -84,10 +90,9 @@ c_int init_linsys_solver_pardiso(pardiso_solver ** sp, const csc * P, const csc 
  * Solve linear system and store result in b
  * @param  s        Linear system solver structure
  * @param  b        Right-hand side
- * @param  settings OSQP solver settings
  * @return          Exitflag
  */
-c_int solve_linsys_pardiso(pardiso_solver * s, c_float * b, const OSQPSettings * settings);
+c_int solve_linsys_pardiso(pardiso_solver * s, c_float * b);
 
 
 /**
@@ -95,21 +100,18 @@ c_int solve_linsys_pardiso(pardiso_solver * s, c_float * b, const OSQPSettings *
  * @param  s        Linear system solver structure
  * @param  P        Matrix P
  * @param  A        Matrix A
- * @param  settings Solver settings
  * @return          Exitflag
  */
-c_int update_linsys_solver_matrices_pardiso(pardiso_solver * s,
-		const csc *P, const csc *A, const OSQPSettings *settings);
+c_int update_linsys_solver_matrices_pardiso(pardiso_solver * s, const csc *P, const csc *A);
 
 
 /**
  * Update rho parameter in linear system solver structure
- * @param  s   Linear system solver structure
- * @param  rho new rho value
- * @param  m   number of constraints
- * @return     exitflag
+ * @param  s        Linear system solver structure
+ * @param  rho_vec  new rho_vec value
+ * @return          exitflag
  */
-c_int update_linsys_solver_rho_vec_pardiso(pardiso_solver * s, const c_float * rho_vec, const c_int m);
+c_int update_linsys_solver_rho_vec_pardiso(pardiso_solver * s, const c_float * rho_vec);
 
 
 /**

--- a/lin_sys/direct/qdldl/qdldl_interface.h
+++ b/lin_sys/direct/qdldl/qdldl_interface.h
@@ -20,7 +20,7 @@ struct qdldl {
      * @name Functions
      * @{
      */
-    c_int (*solve)(struct qdldl * self, c_float * b, const OSQPSettings * settings);
+    c_int (*solve)(struct qdldl * self, c_float * b);
 
 #ifndef EMBEDDED
     void (*free)(struct qdldl * self); ///< Free workspace (only if desktop)
@@ -28,8 +28,8 @@ struct qdldl {
 
     // This used only in non embedded or embedded 2 version
 #if EMBEDDED != 1
-    c_int (*update_matrices)(struct qdldl * self, const csc *P, const csc *A, const OSQPSettings *settings); ///< Update solver matrices
-    c_int (*update_rho_vec)(struct qdldl * self, const c_float * rho_vec, const c_int m); ///< Update solver matrices
+    c_int (*update_matrices)(struct qdldl * self, const csc *P, const csc *A);  ///< Update solver matrices
+    c_int (*update_rho_vec)(struct qdldl * self, const c_float * rho_vec);      ///< Update rho_vec parameter
 #endif
 
 #ifndef EMBEDDED
@@ -41,10 +41,18 @@ struct qdldl {
      * @name Attributes
      * @{
      */
-    csc *L;         ///< lower triangular matrix in LDL factorization
-    c_float *Dinv;  ///< inverse of diag matrix in LDL (as a vector)
-    c_int   *P;     ///< permutation of KKT matrix for factorization
-    c_float *bp;    ///< workspace memory for solves
+    csc *L;                 ///< lower triangular matrix in LDL factorization
+    c_float *Dinv;          ///< inverse of diag matrix in LDL (as a vector)
+    c_int   *P;             ///< permutation of KKT matrix for factorization
+    c_float *bp;            ///< workspace memory for solves
+    c_float *sol;           ///< solution to the KKT system
+    c_float *rho_inv_vec;   ///< parameter vector
+    c_float sigma;          ///< scalar parameter
+#ifndef EMBEDDED
+    c_int polish;           ///< polishing flag
+#endif
+    c_int n;                ///< number of QP variables
+    c_int m;                ///< number of QP constraints
 
 
 #if EMBEDDED != 1
@@ -84,10 +92,9 @@ c_int init_linsys_solver_qdldl(qdldl_solver ** sp, const csc * P, const csc * A,
  * Solve linear system and store result in b
  * @param  s        Linear system solver structure
  * @param  b        Right-hand side
- * @param  settings OSQP solver settings
  * @return          Exitflag
  */
-c_int solve_linsys_qdldl(qdldl_solver * s, c_float * b, const OSQPSettings * settings);
+c_int solve_linsys_qdldl(qdldl_solver * s, c_float * b);
 
 
 #if EMBEDDED != 1
@@ -96,23 +103,20 @@ c_int solve_linsys_qdldl(qdldl_solver * s, c_float * b, const OSQPSettings * set
  * @param  s        Linear system solver structure
  * @param  P        Matrix P
  * @param  A        Matrix A
- * @param  settings Solver settings
  * @return          Exitflag
  */
-c_int update_linsys_solver_matrices_qdldl(qdldl_solver * s,
-		const csc *P, const csc *A, const OSQPSettings *settings);
+c_int update_linsys_solver_matrices_qdldl(qdldl_solver * s, const csc *P, const csc *A);
 
 
 
 
 /**
- * Update rho parameter in linear system solver structure
- * @param  s   Linear system solver structure
- * @param  rho new rho value
- * @param  m   number of constraints
- * @return     exitflag
+ * Update rho_vec parameter in linear system solver structure
+ * @param  s        Linear system solver structure
+ * @param  rho_vec  new rho_vec value
+ * @return          exitflag
  */
-c_int update_linsys_solver_rho_vec_qdldl(qdldl_solver * s, const c_float * rho_vec, const c_int m);
+c_int update_linsys_solver_rho_vec_qdldl(qdldl_solver * s, const c_float * rho_vec);
 
 #endif
 

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -138,8 +138,7 @@ c_int update_rho_vec(OSQPWorkspace *work) {
   // Update rho_vec in KKT matrix if constraints type has changed
   if (constr_type_changed == 1) {
     exitflag = work->linsys_solver->update_rho_vec(work->linsys_solver,
-                                                   work->rho_vec,
-                                                   work->data->m);
+                                                   work->rho_vec);
   }
 
   return exitflag;
@@ -178,25 +177,12 @@ static void compute_rhs(OSQPWorkspace *work) {
   }
 }
 
-static void update_z_tilde(OSQPWorkspace *work) {
-  c_int i; // Index
-
-  for (i = 0; i < work->data->m; i++) {
-    work->xz_tilde[i + work->data->n] = work->z_prev[i] + work->rho_inv_vec[i] *
-                                        (work->xz_tilde[i + work->data->n] -
-                                         work->y[i]);
-  }
-}
-
 void update_xz_tilde(OSQPWorkspace *work) {
   // Compute right-hand side
   compute_rhs(work);
 
   // Solve linear system
-  work->linsys_solver->solve(work->linsys_solver, work->xz_tilde, work->settings);
-
-  // Update z_tilde variable after solving linear system
-  update_z_tilde(work);
+  work->linsys_solver->solve(work->linsys_solver, work->xz_tilde);
 }
 
 void update_x(OSQPWorkspace *work) {

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -1045,8 +1045,7 @@ c_int osqp_update_P(OSQPWorkspace *work,
   // Update linear system structure with new data
   exitflag = work->linsys_solver->update_matrices(work->linsys_solver,
                                                   work->data->P,
-                                                  work->data->A,
-                                                  work->settings);
+                                                  work->data->A);
 
   // Reset solver information
   reset_info(work->info);
@@ -1122,8 +1121,7 @@ c_int osqp_update_A(OSQPWorkspace *work,
   // Update linear system structure with new data
   exitflag = work->linsys_solver->update_matrices(work->linsys_solver,
                                                   work->data->P,
-                                                  work->data->A,
-                                                  work->settings);
+                                                  work->data->A);
 
   // Reset solver information
   reset_info(work->info);
@@ -1231,8 +1229,7 @@ c_int osqp_update_P_A(OSQPWorkspace *work,
   // Update linear system structure with new data
   exitflag = work->linsys_solver->update_matrices(work->linsys_solver,
                                                   work->data->P,
-                                                  work->data->A,
-                                                  work->settings);
+                                                  work->data->A);
 
   // Reset solver information
   reset_info(work->info);
@@ -1291,8 +1288,7 @@ c_int osqp_update_rho(OSQPWorkspace *work, c_float rho_new) {
 
   // Update rho_vec in KKT matrix
   exitflag = work->linsys_solver->update_rho_vec(work->linsys_solver,
-                                                 work->rho_vec,
-                                                 work->data->m);
+                                                 work->rho_vec);
 
 #ifdef PROFILING
   if (work->rho_update_from_solve == 0)

--- a/src/polish.c
+++ b/src/polish.c
@@ -162,7 +162,7 @@ static void iterative_refinement(OSQPWorkspace *work,
       mat_vec(work->pol->Ared, z, rhs + work->data->n, -1);
 
       // Solve linear system. Store solution in rhs
-      p->solve(p, rhs, work->settings);
+      p->solve(p, rhs);
 
       // Update solution
       for (j = 0; j < n; j++) {
@@ -238,7 +238,7 @@ c_int polish(OSQPWorkspace *work) {
 
   // Solve the reduced KKT system
   pol_sol = vec_copy(rhs_red, work->data->n + mred);
-  plsh->solve(plsh, pol_sol, work->settings);
+  plsh->solve(plsh, pol_sol);
 
   // Perform iterative refinement to compensate for the regularization error
   iterative_refinement(work, plsh, pol_sol, rhs_red);

--- a/tests/basic_qp/test_basic_qp.h
+++ b/tests/basic_qp/test_basic_qp.h
@@ -157,22 +157,22 @@ static char* test_basic_qp_solve_pardiso()
   osqp_solve(work);
 
   // Compare solver statuses
-  mu_assert("Basic QP test solve: Error in solver status!",
+  mu_assert("Basic QP test solve Pardiso: Error in solver status!",
             work->info->status_val == sols_data->status_test);
 
   // Compare primal solutions
-  mu_assert("Basic QP test solve: Error in primal solution!",
+  mu_assert("Basic QP test solve Pardiso: Error in primal solution!",
             vec_norm_inf_diff(work->solution->x, sols_data->x_test,
                               data->n) < TESTS_TOL);
 
   // Compare dual solutions
-  mu_assert("Basic QP test solve: Error in dual solution!",
+  mu_assert("Basic QP test solve Pardiso: Error in dual solution!",
             vec_norm_inf_diff(work->solution->y, sols_data->y_test,
                               data->m) < TESTS_TOL);
 
 
   // Compare objective values
-  mu_assert("Basic QP test solve: Error in objective value!",
+  mu_assert("Basic QP test solve Pardiso: Error in objective value!",
             c_absval(work->info->obj_val - sols_data->obj_value_test) <
             TESTS_TOL);
 
@@ -408,8 +408,8 @@ static const char* test_basic_qp_update_rho()
   osqp_set_default_settings(settings);
   settings->rho               = rho;
   settings->adaptive_rho      = 0; // Disable adaptive rho for this test
-  settings->eps_abs           = 1e-04;
-  settings->eps_rel           = 1e-04;
+  settings->eps_abs           = 5e-05;
+  settings->eps_rel           = 5e-05;
   settings->check_termination = 1;
 
   // Setup workspace
@@ -452,8 +452,8 @@ static const char* test_basic_qp_update_rho()
   settings->rho               = 0.1;
   settings->adaptive_rho      = 0;
   settings->check_termination = 1;
-  settings->eps_abs           = 1e-04;
-  settings->eps_rel           = 1e-04;
+  settings->eps_abs           = 5e-05;
+  settings->eps_rel           = 5e-05;
 
   // Setup workspace
   exitflag = osqp_setup(&work, data, settings);

--- a/tests/solve_linsys/generate_problem.py
+++ b/tests/solve_linsys/generate_problem.py
@@ -27,7 +27,8 @@ test_solve_KKT_KKT = spa.vstack([
 test_solve_KKT_rhs = np.random.randn(test_solve_KKT_m + test_solve_KKT_n)
 test_solve_KKT_x = spla.splu(test_solve_KKT_KKT.tocsc()).solve(test_solve_KKT_rhs)
 
-# import ipdb; ipdb.set_trace()
+test_solve_KKT_x[test_solve_KKT_n:] = test_solve_KKT_rhs[test_solve_KKT_n:] + \
+                                      test_solve_KKT_x[test_solve_KKT_n:] / test_solve_KKT_rho
 
 # Generate test data and solutions
 data = {'test_solve_KKT_n': test_solve_KKT_n,

--- a/tests/solve_linsys/test_solve_linsys.h
+++ b/tests/solve_linsys/test_solve_linsys.h
@@ -30,7 +30,7 @@ static const char* test_solveKKT() {
                                 settings->sigma, rho_vec, LINSYS_SOLVER, 0);
 
   // Solve  KKT x = b via LDL given factorization
-  s->solve(s, data->test_solve_KKT_rhs, settings);
+  s->solve(s, data->test_solve_KKT_rhs);
 
   mu_assert(
     "Linear systems solve tests: error in forming and solving KKT system!",
@@ -75,7 +75,7 @@ static char* test_solveKKT_pardiso() {
                                 settings->sigma, rho_vec, MKL_PARDISO_SOLVER, 0);
 
   // Solve  KKT x = b via LDL given factorization
-  s->solve(s, data->test_solve_KKT_rhs, settings);
+  s->solve(s, data->test_solve_KKT_rhs);
 
   mu_assert(
     "Linear systems solve tests: error in forming and solving KKT system with PARDISO!",


### PR DESCRIPTION
The main change is that `linsys_solver->solve` function now computes the vector `(x_tilde,z_tilde)` instead of `(x_tilde,nu)` (in the non-polishing mode). OSQP should be agnostic to `nu` since indirect solvers do not need this vector.

I have also removed unused arguments of linsys solver functions.