### PR TITLE
Add more unit tests to improve coverage

### DIFF
--- a/docs/examples/huber.rst
+++ b/docs/examples/huber.rst
@@ -49,14 +49,14 @@ Python
         + np.multiply(10.*np.random.rand(m), 1. - ind95)
 
     # OSQP data
-    Im = sparse.eye(m).tocsc()
+    Im = sparse.eye(m, format='csc')
     P = sparse.block_diag((sparse.csc_matrix((n, n)), 2*Im,
-                           sparse.csc_matrix((m, m)))).tocsc()
+                           sparse.csc_matrix((m, m))),
+                           format='csc')
     q = np.append(np.zeros(m+n), 2*np.ones(m))
     A = sparse.vstack([
             sparse.hstack([Ad, -Im, Im]),
-            sparse.hstack([Ad, -Im, -Im])
-        ]).tocsc()
+            sparse.hstack([Ad, -Im, -Im])], format='csc')
     l = np.hstack([b, -np.inf*np.ones(m)])
     u = np.hstack([np.inf*np.ones(m), b])
 

--- a/docs/examples/huber.rst
+++ b/docs/examples/huber.rst
@@ -49,9 +49,9 @@ Python
         + np.multiply(10.*np.random.rand(m), 1. - ind95)
 
     # OSQP data
-    Im = sparse.eye(m, format='csc')
-    P = sparse.block_diag((sparse.csc_matrix((n, n)), 2*Im,
-                           sparse.csc_matrix((m, m))),
+    Im = sparse.eye(m)
+    P = sparse.block_diag([sparse.csc_matrix((n, n)), 2*Im,
+                           sparse.csc_matrix((m, m))],
                            format='csc')
     q = np.append(np.zeros(m+n), 2*np.ones(m))
     A = sparse.vstack([

--- a/docs/examples/lasso.rst
+++ b/docs/examples/lasso.rst
@@ -58,7 +58,7 @@ Python
     q = np.zeros(2*n + m)
     A = sparse.vstack([sparse.hstack([Ad, -Im, Onm.T]),
                        sparse.hstack([In, Onm, -In]),
-                       sparse.hstack([In, Onm, In])]).tocsc()
+                       sparse.hstack([In, Onm, In])], format='csc')
     l = np.hstack([b, -np.inf * np.ones(n), np.zeros(n)])
     u = np.hstack([b, np.zeros(n), np.inf * np.ones(n)])
 

--- a/docs/examples/lasso.rst
+++ b/docs/examples/lasso.rst
@@ -54,7 +54,7 @@ Python
     Onm = sparse.csc_matrix((n, m))
 
     # OSQP data
-    P = sparse.block_diag((On, sparse.eye(m), On), format='csc')
+    P = sparse.block_diag([On, sparse.eye(m), On], format='csc')
     q = np.zeros(2*n + m)
     A = sparse.vstack([sparse.hstack([Ad, -Im, Onm.T]),
                        sparse.hstack([In, Onm, -In]),

--- a/docs/examples/least-squares.rst
+++ b/docs/examples/least-squares.rst
@@ -42,8 +42,7 @@ Python
     q = np.zeros(n+m)
     A = sparse.vstack([
             sparse.hstack([Ad, -sparse.eye(m)]),
-            sparse.hstack((sparse.eye(n), sparse.csc_matrix((n, m))))
-        ]).tocsc()
+            sparse.hstack([sparse.eye(n), sparse.csc_matrix((n, m))])], format='csc')
     l = np.hstack([b, np.zeros(n)])
     u = np.hstack([b, np.ones(n)])
 

--- a/docs/examples/least-squares.rst
+++ b/docs/examples/least-squares.rst
@@ -38,7 +38,7 @@ Python
     b = np.random.randn(m)
 
     # OSQP data
-    P = sparse.block_diag((sparse.csc_matrix((n, n)), sparse.eye(m)), format='csc')
+    P = sparse.block_diag([sparse.csc_matrix((n, n)), sparse.eye(m)], format='csc')
     q = np.zeros(n+m)
     A = sparse.vstack([
             sparse.hstack([Ad, -sparse.eye(m)]),

--- a/docs/examples/mpc.rst
+++ b/docs/examples/mpc.rst
@@ -81,7 +81,7 @@ Python
     # Cast MPC problem to a QP: x = (x(0),x(1),...,x(N),u(0),...,u(N-1))
     # - quadratic objective
     P = sparse.block_diag([sparse.kron(sparse.eye(N), Q), QN,
-                           sparse.kron(sparse.eye(N), R)]).tocsc()
+                           sparse.kron(sparse.eye(N), R)], format='csc')
     # - linear objective
     q = np.hstack([np.kron(np.ones(N), -Q.dot(xr)), -QN.dot(xr),
                    np.zeros(N*nu)])
@@ -96,7 +96,7 @@ Python
     lineq = np.hstack([np.kron(np.ones(N+1), xmin), np.kron(np.ones(N), umin)])
     uineq = np.hstack([np.kron(np.ones(N+1), xmax), np.kron(np.ones(N), umax)])
     # - OSQP constraints
-    A = sparse.vstack([Aeq, Aineq]).tocsc()
+    A = sparse.vstack([Aeq, Aineq], format='csc')
     l = np.hstack([leq, lineq])
     u = np.hstack([ueq, uineq])
 

--- a/docs/examples/portfolio.rst
+++ b/docs/examples/portfolio.rst
@@ -60,7 +60,7 @@ Python
             sparse.hstack([F.T, -sparse.eye(k)]),
             sparse.hstack([sparse.csc_matrix(np.ones((1, n))), sparse.csc_matrix((1, k))]),
             sparse.hstack((sparse.eye(n), sparse.csc_matrix((n, k))))
-        ]).tocsc()
+        ], format='csc')
     l = np.hstack([np.zeros(k), 1., np.zeros(n)])
     u = np.hstack([np.zeros(k), 1., np.ones(n)])
 

--- a/docs/examples/portfolio.rst
+++ b/docs/examples/portfolio.rst
@@ -54,7 +54,7 @@ Python
     gamma = 1
 
     # OSQP data
-    P = sparse.block_diag((D, sparse.eye(k)), format='csc')
+    P = sparse.block_diag([D, sparse.eye(k)], format='csc')
     q = np.hstack([-mu / (2*gamma), np.zeros(k)])
     A = sparse.vstack([
             sparse.hstack([F.T, -sparse.eye(k)]),

--- a/docs/examples/svm.rst
+++ b/docs/examples/svm.rst
@@ -49,7 +49,7 @@ Python
 
     # OSQP data
     Im = sparse.eye(m)
-    P = sparse.block_diag((sparse.eye(n), sparse.csc_matrix((m, m))), format='csc')
+    P = sparse.block_diag([sparse.eye(n), sparse.csc_matrix((m, m))], format='csc')
     q = np.hstack([np.zeros(n), gamma*np.ones(m)])
     A = sparse.vstack([
             sparse.hstack([sparse.diags(b).dot(Ad), -Im]),

--- a/docs/examples/svm.rst
+++ b/docs/examples/svm.rst
@@ -45,7 +45,7 @@ Python
     Ad = sparse.vstack([
             A_upp / np.sqrt(n) + (A_upp != 0.).astype(float) / n,
             A_low / np.sqrt(n) - (A_low != 0.).astype(float) / n
-         ]).tocsc()
+         ], format='csc')
 
     # OSQP data
     Im = sparse.eye(m)
@@ -54,7 +54,7 @@ Python
     A = sparse.vstack([
             sparse.hstack([sparse.diags(b).dot(Ad), -Im]),
             sparse.hstack([sparse.csc_matrix((m, n)), Im])
-        ]).tocsc()
+        ], format='csc')
     l = np.hstack([-np.inf*np.ones(m), np.zeros(m)])
     u = np.hstack([-np.ones(m), np.inf*np.ones(m)])
 
@@ -126,7 +126,7 @@ CVXPY
     A = sparse.vstack([
             A_upp / np.sqrt(n) + (A_upp != 0.).astype(float) / n,
             A_low / np.sqrt(n) - (A_low != 0.).astype(float) / n
-        ]).tocsc()
+        ], format='csc')
 
     # Define problem
     x = Variable(n)

--- a/include/constants.h
+++ b/include/constants.h
@@ -31,14 +31,14 @@ extern "C" {
 # define OSQP_SOLVED_INACCURATE (2)
 # define OSQP_SOLVED (1)
 # define OSQP_MAX_ITER_REACHED (-2)
-# define OSQP_PRIMAL_INFEASIBLE (-3) /* primal infeasible  */
-# define OSQP_DUAL_INFEASIBLE (-4)   /* dual infeasible */
-# define OSQP_SIGINT (-5)            /* interrupted by user */
+# define OSQP_PRIMAL_INFEASIBLE (-3)    /* primal infeasible  */
+# define OSQP_DUAL_INFEASIBLE (-4)      /* dual infeasible */
+# define OSQP_SIGINT (-5)               /* interrupted by user */
 # ifdef PROFILING
 #  define OSQP_TIME_LIMIT_REACHED (-6)
 # endif // ifdef PROFILING
-# define OSQP_NON_CVX (-7)           /* problem non convex */
-# define OSQP_UNSOLVED (-10) /* Unsolved. Only setup function has been called */
+# define OSQP_NON_CVX (-7)              /* problem non convex */
+# define OSQP_UNSOLVED (-10)            /* Unsolved. Only setup function has been called */
 
 
 /*************************
@@ -66,8 +66,7 @@ static const char *LINSYS_SOLVER_NAME[] = {
 # define RHO_MIN (1e-06)
 # define RHO_MAX (1e06)
 # define RHO_EQ_OVER_RHO_INEQ (1e03)
-# define RHO_TOL (1e-04) ///< Tolerance for detecting if an inequality is set to
-                         // equality
+# define RHO_TOL (1e-04) ///< tolerance for detecting if an inequality is set to equality
 
 
 # ifndef EMBEDDED
@@ -82,8 +81,8 @@ static const char *LINSYS_SOLVER_NAME[] = {
 # define WARM_START (1)
 # define SCALING (10)
 
-# define MIN_SCALING (1e-04) ///< Minimum scaling value
-# define MAX_SCALING (1e+04) ///< Maximum scaling value
+# define MIN_SCALING (1e-04) ///< minimum scaling value
+# define MAX_SCALING (1e+04) ///< maximum scaling value
 
 
 # ifndef OSQP_NULL
@@ -91,34 +90,25 @@ static const char *LINSYS_SOLVER_NAME[] = {
 # endif /* ifndef OSQP_NULL */
 
 # ifndef OSQP_NAN
-#  define OSQP_NAN ((c_float)0x7fc00000UL) // Not a Number
+#  define OSQP_NAN ((c_float)0x7fc00000UL)  // not a number
 # endif /* ifndef OSQP_NAN */
 
 # ifndef OSQP_INFTY
-#  define OSQP_INFTY ((c_float)1e20) // Infinity
+#  define OSQP_INFTY ((c_float)1e20)        // infinity
 # endif /* ifndef OSQP_INFTY */
 
 
 # if EMBEDDED != 1
 #  define ADAPTIVE_RHO (1)
 #  define ADAPTIVE_RHO_INTERVAL (0)
-#  define ADAPTIVE_RHO_FRACTION (0.4)           ///< Fraction of setup time
-                                                // after which we update rho
-#  define ADAPTIVE_RHO_MULTIPLE_TERMINATION (4) ///< Multiple of termination
-                                                // check time we update rho if
-                                                // profiling disabled
-#  define ADAPTIVE_RHO_FIXED (100)              ///< Number of iterations after
-                                                // which we update rho if
-                                                // termination check if disabled
-                                                // and profiling disabled
-#  define ADAPTIVE_RHO_TOLERANCE (5)            ///< Tolerance for adopting new
-                                                // rho. Number of times the new
-                                                // rho is larger or smaller than
-                                                // the current one
+#  define ADAPTIVE_RHO_FRACTION (0.4)           ///< fraction of setup time after which we update rho
+#  define ADAPTIVE_RHO_MULTIPLE_TERMINATION (4) ///< multiple of check_termination after which we update rho (if PROFILING disabled)
+#  define ADAPTIVE_RHO_FIXED (100)              ///< number of iterations after which we update rho if termination_check  and PROFILING are disabled
+#  define ADAPTIVE_RHO_TOLERANCE (5)            ///< tolerance for adopting new rho; minimum ratio between new rho and the current one
 # endif // if EMBEDDED != 1
 
 # ifdef PROFILING
-#  define TIME_LIMIT (0) ///< Disable time limit as default
+#  define TIME_LIMIT (0)                        ///< Disable time limit as default
 # endif // ifdef PROFILING
 
 /* Printing */

--- a/include/types.h
+++ b/include/types.h
@@ -17,15 +17,13 @@ extern "C" {
  *  Matrix in compressed-column or triplet form
  */
 typedef struct {
-  c_int    nzmax; ///< maximum number of entries.
+  c_int    nzmax; ///< maximum number of entries
   c_int    m;     ///< number of rows
   c_int    n;     ///< number of columns
-  c_int   *p;     ///< column pointers (size n+1) (col indices (size nzmax)
-                  // start from 0 when using triplet format (direct KKT matrix
-                  // formation))
+  c_int   *p;     ///< column pointers (size n+1); col indices (size nzmax) start from 0 when using triplet format (direct KKT matrix formation)
   c_int   *i;     ///< row indices, size nzmax starting from 0
   c_float *x;     ///< numerical values, size nzmax
-  c_int    nz;    ///< # of entries in triplet matrix, -1 for csc
+  c_int    nz;    ///< number of entries in triplet matrix, -1 for csc
 } csc;
 
 /**
@@ -55,7 +53,7 @@ typedef struct {
  * Solution structure
  */
 typedef struct {
-  c_float *x; ///< Primal solution
+  c_float *x; ///< primal solution
   c_float *y; ///< Lagrange multiplier associated to \f$l <= Ax <= u\f$
 } OSQPSolution;
 
@@ -69,8 +67,7 @@ typedef struct {
   c_int status_val;    ///< status as c_int, defined in constants.h
 
 # ifndef EMBEDDED
-  c_int status_polish; ///< polish status: successful (1), unperformed (0), (-1)
-                       // unsuccessful
+  c_int status_polish; ///< polish status: successful (1), unperformed (0), (-1) unsuccessful
 # endif // ifndef EMBEDDED
 
   c_float obj_val;     ///< primal objective
@@ -98,7 +95,7 @@ typedef struct {
  * Polish structure
  */
 typedef struct {
-  csc *Ared;          ///< Active rows of A.
+  csc *Ared;          ///< active rows of A
   ///<    Ared = vstack[Alow, Aupp]
   c_int    n_low;     ///< number of lower-active rows
   c_int    n_upp;     ///< number of upper-active rows
@@ -126,8 +123,7 @@ typedef struct {
 typedef struct {
   c_int    n; ///< number of variables n
   c_int    m; ///< number of constraints m
-  csc     *P; ///< the upper triangular part of the quadratic cost matrix
-              ///  P in csc format (size n x n).
+  csc     *P; ///< the upper triangular part of the quadratic cost matrix P in csc format (size n x n).
   csc     *A; ///< linear constraints matrix A in csc format (size m x n)
   c_float *q; ///< dense array for linear part of cost function (size n)
   c_float *l; ///< dense array for lower bound (size m)
@@ -141,24 +137,18 @@ typedef struct {
 typedef struct {
   c_float rho;                    ///< ADMM step rho
   c_float sigma;                  ///< ADMM step sigma
-  c_int   scaling;                ///< heuristic data scaling iterations. If 0,
-                                  // scaling disabled
+  c_int   scaling;                ///< heuristic data scaling iterations; if 0, then disabled.
 
 # if EMBEDDED != 1
   c_int   adaptive_rho;           ///< boolean, is rho step size adaptive?
-  c_int   adaptive_rho_interval;  ///< Number of iterations between rho
-                                  // adaptations rho. If 0, it is automatic
-  c_float adaptive_rho_tolerance; ///< Tolerance X for adapting rho. The new rho
-                                  // has to be X times larger or 1/X times
-                                  // smaller than the current one to trigger a
-                                  // new factorization.
+  c_int   adaptive_rho_interval;  ///< number of iterations between rho adaptations; if 0, then it is automatic
+  c_float adaptive_rho_tolerance; ///< tolerance X for adapting rho. The new rho has to be X times larger or 1/X times smaller than the current one to trigger a new factorization.
 #  ifdef PROFILING
-  c_float adaptive_rho_fraction;  ///< Interval for adapting rho (fraction of
-                                  // the setup time)
+  c_float adaptive_rho_fraction;  ///< interval for adapting rho (fraction of the setup time)
 #  endif // Profiling
 # endif // EMBEDDED != 1
 
-  c_int                   max_iter;      ///< maximum iterations
+  c_int                   max_iter;      ///< maximum number of iterations
   c_float                 eps_abs;       ///< absolute convergence tolerance
   c_float                 eps_rel;       ///< relative convergence tolerance
   c_float                 eps_prim_inf;  ///< primal infeasibility tolerance
@@ -167,25 +157,19 @@ typedef struct {
   enum linsys_solver_type linsys_solver; ///< linear system solver to use
 
 # ifndef EMBEDDED
-  c_float delta;                         ///< regularization parameter for
-                                         // polish
+  c_float delta;                         ///< regularization parameter for polishing
   c_int   polish;                        ///< boolean, polish ADMM solution
-  c_int   polish_refine_iter;            ///< iterative refinement steps in
-                                         // polish
+  c_int   polish_refine_iter;            ///< number of iterative refinement steps in polishing
 
   c_int verbose;                         ///< boolean, write out progress
 # endif // ifndef EMBEDDED
 
-  c_int scaled_termination;              ///< boolean, use scaled termination
-                                         // criteria
-  c_int check_termination;               ///< integer, check termination
-                                         // interval. If 0, termination checking
-                                         // is disabled
+  c_int scaled_termination;              ///< boolean, use scaled termination criteria
+  c_int check_termination;               ///< integer, check termination interval; if 0, then termination checking is disabled
   c_int warm_start;                      ///< boolean, warm start
 
 # ifdef PROFILING
-  c_float time_limit;                    ///< maximum seconds allowed to solve
-                                         // the problem
+  c_float time_limit;                    ///< maximum number of seconds allowed to solve the problem; if 0, then disabled
 # endif // ifdef PROFILING
 } OSQPSettings;
 
@@ -215,8 +199,7 @@ typedef struct {
   /** @} */
 
 # if EMBEDDED != 1
-  c_int *constr_type; ///< Type of constraints: loose (-1), equality (1),
-                      // inequality (0)
+  c_int *constr_type; ///< Type of constraints: loose (-1), equality (1), inequality (0)
 # endif // if EMBEDDED != 1
 
   /**
@@ -242,9 +225,9 @@ typedef struct {
    * approximate tolerances computation and adapting rho
    * @{
    */
-  c_float *Ax;  ///< Scaled A * x
-  c_float *Px;  ///< Scaled P * x
-  c_float *Aty; ///< Scaled A * x
+  c_float *Ax;  ///< scaled A * x
+  c_float *Px;  ///< scaled P * x
+  c_float *Aty; ///< scaled A * x
 
   /** @} */
 
@@ -252,7 +235,7 @@ typedef struct {
    * @name Primal infeasibility variables
    * @{
    */
-  c_float *delta_y;   ///< Difference of consecutive dual iterates
+  c_float *delta_y;   ///< difference between consecutive dual iterates
   c_float *Atdelta_y; ///< A' * delta_y
 
   /** @} */
@@ -261,7 +244,7 @@ typedef struct {
    * @name Dual infeasibility variables
    * @{
    */
-  c_float *delta_x;  ///< Difference of consecutive primal iterates
+  c_float *delta_x;  ///< difference between consecutive primal iterates
   c_float *Pdelta_x; ///< P * delta_x
   c_float *Adelta_x; ///< A * delta_x
 
@@ -273,21 +256,19 @@ typedef struct {
    */
 
   c_float *D_temp;   ///< temporary primal variable scaling vectors
-  c_float *D_temp_A; ///< temporary primal variable scaling vectors storing
-                     // norms of A columns
-  c_float *E_temp;   ///< temporary constraints scaling vectors storing norms of
-                     // A' columns
+  c_float *D_temp_A; ///< temporary primal variable scaling vectors storing norms of A columns
+  c_float *E_temp;   ///< temporary constraints scaling vectors storing norms of A' columns
 
 
   /** @} */
 
-  OSQPSettings *settings; ///< Problem settings
-  OSQPScaling  *scaling;  ///< Scaling vectors
-  OSQPSolution *solution; ///< Problem solution
-  OSQPInfo     *info;     ///< Solver information
+  OSQPSettings *settings; ///< problem settings
+  OSQPScaling  *scaling;  ///< scaling vectors
+  OSQPSolution *solution; ///< problem solution
+  OSQPInfo     *info;     ///< solver information
 
 # ifdef PROFILING
-  OSQPTimer *timer;       ///< Timer object
+  OSQPTimer *timer;       ///< timer object
 
   /// flag indicating whether the solve function has been run before
   c_int first_run;
@@ -313,19 +294,17 @@ typedef struct {
  *      on the choice
  */
 struct linsys_solver {
-  enum linsys_solver_type type;                 ///< Linear system solver type
-  // Functions
+  enum linsys_solver_type type;                 ///< linear system solver type functions
   c_int (*solve)(LinSysSolver *self,
-                 c_float      *b);              ///< Solve linear system
+                 c_float      *b);              ///< solve linear system
 
 # ifndef EMBEDDED
-  void (*free)(LinSysSolver *self);             ///< Free linear system solver
-                                                // (only in desktop version)
+  void (*free)(LinSysSolver *self);             ///< free linear system solver (only in desktop version)
 # endif // ifndef EMBEDDED
 
 # if EMBEDDED != 1
   c_int (*update_matrices)(LinSysSolver *s,
-                           const csc *P,            ///< Update matrices P
+                           const csc *P,            ///< update matrices P
                            const csc *A);           //   and A in the solver
 
   c_int (*update_rho_vec)(LinSysSolver  *s,
@@ -333,7 +312,7 @@ struct linsys_solver {
 # endif // if EMBEDDED != 1
 
 # ifndef EMBEDDED
-  c_int nthreads; ///< Number of threads active
+  c_int nthreads; ///< number of threads active
 # endif // ifndef EMBEDDED
 };
 

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -910,7 +910,7 @@ c_int validate_settings(const OSQPSettings *settings) {
   }
 # endif /* ifdef PROFILING */
 
-  if (settings->adaptive_rho_tolerance < 1) {
+  if (settings->adaptive_rho_tolerance < 1.0) {
 # ifdef PRINTING
     c_eprint("adaptive_rho_tolerance must be >= 1");
 # endif /* ifdef PRINTING */
@@ -924,14 +924,21 @@ c_int validate_settings(const OSQPSettings *settings) {
     return 1;
   }
 
-  if (settings->rho <= 0) {
+  if (settings->rho <= 0.0) {
 # ifdef PRINTING
     c_eprint("rho must be positive");
 # endif /* ifdef PRINTING */
     return 1;
   }
 
-  if (settings->delta <= 0) {
+  if (settings->sigma <= 0.0) {
+# ifdef PRINTING
+    c_eprint("sigma must be positive");
+# endif /* ifdef PRINTING */
+    return 1;
+  }
+
+  if (settings->delta <= 0.0) {
 # ifdef PRINTING
     c_eprint("delta must be positive");
 # endif /* ifdef PRINTING */
@@ -945,44 +952,46 @@ c_int validate_settings(const OSQPSettings *settings) {
     return 1;
   }
 
-  if (settings->eps_abs < 0) {
+  if (settings->eps_abs < 0.0) {
 # ifdef PRINTING
     c_eprint("eps_abs must be nonnegative");
 # endif /* ifdef PRINTING */
     return 1;
   }
 
-  if (settings->eps_rel < 0) {
+  if (settings->eps_rel < 0.0) {
 # ifdef PRINTING
     c_eprint("eps_rel must be nonnegative");
 # endif /* ifdef PRINTING */
     return 1;
   }
 
-  if ((settings->eps_rel == 0) && (settings->eps_abs == 0)) {
+  if ((settings->eps_rel == 0.0) &&
+      (settings->eps_abs == 0.0)) {
 # ifdef PRINTING
     c_eprint("at least one of eps_abs and eps_rel must be positive");
 # endif /* ifdef PRINTING */
     return 1;
   }
 
-  if (settings->eps_prim_inf < 0) {
+  if (settings->eps_prim_inf <= 0.0) {
 # ifdef PRINTING
-    c_eprint("eps_prim_inf must be nonnegative");
+    c_eprint("eps_prim_inf must be positive");
 # endif /* ifdef PRINTING */
     return 1;
   }
 
-  if (settings->eps_dual_inf < 0) {
+  if (settings->eps_dual_inf <= 0.0) {
 # ifdef PRINTING
-    c_eprint("eps_dual_inf must be nonnegative");
+    c_eprint("eps_dual_inf must be positive");
 # endif /* ifdef PRINTING */
     return 1;
   }
 
-  if ((settings->alpha <= 0) || (settings->alpha >= 2)) {
+  if ((settings->alpha <= 0.0) ||
+      (settings->alpha >= 2.0)) {
 # ifdef PRINTING
-    c_eprint("alpha must be between 0 and 2");
+    c_eprint("alpha must be strictly between 0 and 2");
 # endif /* ifdef PRINTING */
     return 1;
   }
@@ -994,7 +1003,8 @@ c_int validate_settings(const OSQPSettings *settings) {
     return 1;
   }
 
-  if ((settings->verbose != 0) && (settings->verbose != 1)) {
+  if ((settings->verbose != 0) &&
+      (settings->verbose != 1)) {
 # ifdef PRINTING
     c_eprint("verbose must be either 0 or 1");
 # endif /* ifdef PRINTING */
@@ -1016,7 +1026,8 @@ c_int validate_settings(const OSQPSettings *settings) {
     return 1;
   }
 
-  if ((settings->warm_start != 0) && (settings->warm_start != 1)) {
+  if ((settings->warm_start != 0) &&
+      (settings->warm_start != 1)) {
 # ifdef PRINTING
     c_eprint("warm_start must be either 0 or 1");
 # endif /* ifdef PRINTING */
@@ -1024,7 +1035,7 @@ c_int validate_settings(const OSQPSettings *settings) {
   }
 # ifdef PROFILING
 
-  if (settings->time_limit < 0) {
+  if (settings->time_limit < 0.0) {
 #  ifdef PRINTING
     c_eprint("time_limit must be nonnegative\n");
 #  endif /* ifdef PRINTING */

--- a/src/util.c
+++ b/src/util.c
@@ -167,7 +167,9 @@ void print_polish(OSQPWorkspace *work) {
 
   // Different characters for windows/unix
 # ifdef IS_WINDOWS
-# ifndef PYTHON
+# ifdef PYTHON
+  c_print("   --------");
+# else
   c_print("  ---------");
 # endif /* ifdef PYTHON */
 # else  /* ifdef IS_WINDOWS */

--- a/tests/basic_qp/generate_problem.py
+++ b/tests/basic_qp/generate_problem.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import sparse
 import utils.codegen_utils as cu
 
-P = sparse.triu([[4., 1.], [1., 2.]]).tocsc()
+P = sparse.triu([[4., 1.], [1., 2.]], format='csc')
 q = np.ones(2)
 
 A = sparse.csc_matrix(np.array([[1., 1.], [1., 0.], [0., 1.], [0., 1.]]))

--- a/tests/basic_qp/test_basic_qp.h
+++ b/tests/basic_qp/test_basic_qp.h
@@ -8,8 +8,9 @@
 
 static const char* test_basic_qp_solve()
 {
-  c_int exitflag, tmp;
-  csc *mat_tmp, *P_tmp;
+  c_int exitflag, tmp_int;
+  c_float tmp_float;
+  csc *tmp_mat, *P_tmp;
 
   // Problem settings
   OSQPSettings *settings = (OSQPSettings *)c_malloc(sizeof(OSQPSettings));
@@ -108,26 +109,203 @@ static const char* test_basic_qp_solve()
   // Clean workspace
   osqp_cleanup(work);
 
-  // Setup workspace with empty data
-  exitflag = osqp_setup(&work, OSQP_NULL, settings);
-  mu_assert("Basic QP test solve: Setup should result in error due to empty data",
-            exitflag == OSQP_DATA_VALIDATION_ERROR);
+  /* =============================
+       SETUP WITH WRONG SETTINGS
+     ============================= */
 
   // Setup workspace with empty settings
   exitflag = osqp_setup(&work, data, OSQP_NULL);
   mu_assert("Basic QP test solve: Setup should result in error due to empty settings",
             exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
 
+  // Setup workspace with a wrong number of scaling iterations
+  tmp_int = settings->scaling;
+  settings->scaling = -1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to a negative number of scaling iterations",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->scaling = tmp_int;
+
+  // Setup workspace with wrong settings->adaptive_rho
+  tmp_int = settings->adaptive_rho;
+  settings->adaptive_rho = 2;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->adaptive_rho",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->adaptive_rho = tmp_int;
+
+  // Setup workspace with wrong settings->adaptive_rho_interval
+  tmp_int = settings->adaptive_rho_interval;
+  settings->adaptive_rho_interval = -1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to negative settings->adaptive_rho_interval",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->adaptive_rho_interval = tmp_int;
+
+  // Setup workspace with wrong settings->adaptive_rho_fraction
+  tmp_float = settings->adaptive_rho_fraction;
+  settings->adaptive_rho_fraction = -1.5;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->adaptive_rho_fraction",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->adaptive_rho_fraction = tmp_float;
+
+  // Setup workspace with wrong settings->adaptive_rho_fraction
+  tmp_float = settings->adaptive_rho_tolerance;
+  settings->adaptive_rho_tolerance = 0.5;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to wrong settings->adaptive_rho_tolerance",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->adaptive_rho_tolerance = tmp_float;
+
+  // Setup workspace with wrong settings->polish_refine_iter
+  tmp_int = settings->polish_refine_iter;
+  settings->polish_refine_iter = -3;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to negative settings->polish_refine_iter",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->polish_refine_iter = tmp_int;
+
+  // Setup workspace with wrong settings->rho
+  tmp_float = settings->rho;
+  settings->rho = 0.0;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->rho",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->rho = tmp_float;
+
+  // Setup workspace with wrong settings->sigma
+  tmp_float = settings->sigma;
+  settings->sigma = -0.1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->sigma",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->sigma = tmp_float;
+
+  // Setup workspace with wrong settings->delta
+  tmp_float = settings->delta;
+  settings->delta = -1.1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->delta",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->delta = tmp_float;
+
+  // Setup workspace with wrong settings->max_iter
+  tmp_int = settings->max_iter;
+  settings->max_iter = 0;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->max_iter",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->max_iter = tmp_int;
+
+  // Setup workspace with wrong settings->eps_abs
+  tmp_float = settings->eps_abs;
+  settings->eps_abs = -1.1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to negative settings->eps_abs",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->eps_abs = tmp_float;
+
+  // Setup workspace with wrong settings->eps_rel
+  tmp_float = settings->eps_rel;
+  settings->eps_rel = -0.1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to negative settings->eps_rel",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->eps_rel = tmp_float;
+
+  // Setup workspace with wrong settings->eps_prim_inf
+  tmp_float = settings->eps_prim_inf;
+  settings->eps_prim_inf = -0.1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->eps_prim_inf",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->eps_prim_inf = tmp_float;
+
+  // Setup workspace with wrong settings->eps_dual_inf
+  tmp_float = settings->eps_dual_inf;
+  settings->eps_dual_inf = 0.0;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-positive settings->eps_dual_inf",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->eps_dual_inf = tmp_float;
+
+  // Setup workspace with wrong settings->alpha
+  tmp_float = settings->alpha;
+  settings->alpha = 2.0;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to wrong settings->alpha",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->alpha = tmp_float;
+
+  // Setup workspace with wrong settings->linsys_solver
+  tmp_int = settings->linsys_solver;
+  settings->linsys_solver = 5;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to wrong settings->linsys_solver",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->linsys_solver = tmp_int;
+
+  // Setup workspace with wrong settings->verbose
+  tmp_int = settings->verbose;
+  settings->verbose = 2;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->verbose",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->verbose = tmp_int;
+
+  // Setup workspace with wrong settings->scaled_termination
+  tmp_int = settings->scaled_termination;
+  settings->scaled_termination = 2;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->scaled_termination",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->scaled_termination = tmp_int;
+
+  // Setup workspace with wrong settings->check_termination
+  tmp_int = settings->check_termination;
+  settings->check_termination = -1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->check_termination",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->check_termination = tmp_int;
+
+  // Setup workspace with wrong settings->warm_start
+  tmp_int = settings->warm_start;
+  settings->warm_start = 5;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to non-boolean settings->warm_start",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->warm_start = tmp_int;
+
+  // Setup workspace with wrong settings->time_limit
+  tmp_float = settings->time_limit;
+  settings->time_limit = -0.2;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to wrong settings->time_limit",
+            exitflag == OSQP_SETTINGS_VALIDATION_ERROR);
+  settings->time_limit = tmp_float;
+
+
+  /* =========================
+       SETUP WITH WRONG DATA
+     ========================= */
+
+  // Setup workspace with empty data
+  exitflag = osqp_setup(&work, OSQP_NULL, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to empty data",
+            exitflag == OSQP_DATA_VALIDATION_ERROR);
+
   // Setup workspace with wrong data->m
-  tmp = data->m;
+  tmp_int = data->m;
   data->m = data->m - 1;
   exitflag = osqp_setup(&work, data, settings);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong data->m",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
-  data->m = tmp;
+  data->m = tmp_int;
 
   // Setup workspace with wrong data->n
-  tmp = data->n;
+  tmp_int = data->n;
   data->n = data->n + 1;
   exitflag = osqp_setup(&work, data, settings);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong data->n",
@@ -138,18 +316,26 @@ static const char* test_basic_qp_solve()
   exitflag = osqp_setup(&work, data, settings);
   mu_assert("Basic QP test solve: Setup should result in error due to zero data->n",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
-  data->n = tmp;
+  data->n = tmp_int;
 
   // Setup workspace with wrong P->m
-  tmp = data->P->m;
+  tmp_int = data->P->m;
   data->P->m = data->n + 1;
+  exitflag = osqp_setup(&work, data, settings);
+  mu_assert("Basic QP test solve: Setup should result in error due to wrong P->m",
+            exitflag == OSQP_DATA_VALIDATION_ERROR);
+  data->P->m = tmp_int;
+
+  // Setup workspace with wrong P->n
+  tmp_int = data->P->n;
+  data->P->n = data->n + 1;
   exitflag = osqp_setup(&work, data, settings);
   mu_assert("Basic QP test solve: Setup should result in error due to wrong P->n",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
-  data->P->m = tmp;
+  data->P->n = tmp_int;
 
   // Setup workspace with non-upper-triangular P
-  mat_tmp = data->P;
+  tmp_mat = data->P;
 
   // Construct non-upper-triangular P
   P_tmp = (csc*) c_malloc(sizeof(csc));
@@ -176,7 +362,7 @@ static const char* test_basic_qp_solve()
   exitflag = osqp_setup(&work, data, settings);
   mu_assert("Basic QP test solve: Setup should result in error due to non-triu structure of P",
             exitflag == OSQP_DATA_VALIDATION_ERROR);
-  data->P = mat_tmp;
+  data->P = tmp_mat;
 
   // Setup workspace with non-consistent bounds
   data->l[0] = data->u[0] + 1.0;

--- a/tests/basic_qp2/generate_problem.py
+++ b/tests/basic_qp2/generate_problem.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import sparse
 import utils.codegen_utils as cu
 
-P = sparse.triu([[11., 0.], [0., 0.]]).tocsc()
+P = sparse.triu([[11., 0.], [0., 0.]], format='csc')
 q = np.array([3., 4.])
 
 A = sparse.csc_matrix(np.array([[-1., 0.], [0., -1.], [-1., 3.],

--- a/tests/demo/CMakeLists.txt
+++ b/tests/demo/CMakeLists.txt
@@ -1,0 +1,7 @@
+get_directory_property(headers
+                        DIRECTORY ${PROJECT_SOURCE_DIR}/tests
+                        DEFINITION headers)
+                        
+set(headers ${headers}
+    ${CMAKE_CURRENT_SOURCE_DIR}/demo.h PARENT_SCOPE)
+

--- a/tests/demo/test_demo.h
+++ b/tests/demo/test_demo.h
@@ -1,0 +1,72 @@
+#include "osqp.h"    // OSQP API
+#include "minunit.h" // Basic testing script header
+
+static const char* test_demo_solve()
+{
+  // Load problem data
+  c_float P_x[3] = { 4.0, 1.0, 2.0, };
+  c_int   P_nnz  = 3;
+  c_int   P_i[3] = { 0, 0, 1, };
+  c_int   P_p[3] = { 0, 1, 3, };
+  c_float q[2]   = { 1.0, 1.0, };
+  c_float A_x[4] = { 1.0, 1.0, 1.0, 1.0, };
+  c_int   A_nnz  = 4;
+  c_int   A_i[4] = { 0, 1, 0, 2, };
+  c_int   A_p[3] = { 0, 2, 4, };
+  c_float l[3]   = { 1.0, 0.0, 0.0, };
+  c_float u[3]   = { 1.0, 0.7, 0.7, };
+  c_int n = 2;
+  c_int m = 3;
+
+  c_int exitflag;
+
+  // Problem settings
+  OSQPSettings *settings = (OSQPSettings *)c_malloc(sizeof(OSQPSettings));
+
+  // Structures
+  OSQPWorkspace *work; // Workspace
+  OSQPData *data;      // OSQPData
+
+  // Populate data
+  data = (OSQPData *)c_malloc(sizeof(OSQPData));
+  data->n = n;
+  data->m = m;
+  data->P = csc_matrix(data->n, data->n, P_nnz, P_x, P_i, P_p);
+  data->q = q;
+  data->A = csc_matrix(data->m, data->n, A_nnz, A_x, A_i, A_p);
+  data->l = l;
+  data->u = u;
+
+  // Define solver settings as default
+  osqp_set_default_settings(settings);
+
+  // Setup workspace
+  exitflag = osqp_setup(&work, data, settings);
+
+  // Setup correct
+  mu_assert("Demo test solve: Setup error!", exitflag == 0);
+
+  // Solve Problem
+  osqp_solve(work);
+
+  // Compare solver statuses
+  mu_assert("Demo test solve: Error in solver status!",
+	work->info->status_val == OSQP_SOLVED);
+
+  // Clean workspace
+  osqp_cleanup(work);
+  c_free(data->A);
+  c_free(data->P);
+  c_free(data);
+  c_free(settings);
+
+  return 0;
+}
+
+
+static const char* test_demo()
+{
+  mu_run_test(test_demo_solve);
+
+  return 0;
+}

--- a/tests/lin_alg/generate_problem.py
+++ b/tests/lin_alg/generate_problem.py
@@ -28,9 +28,9 @@ test_vec_ops_ew_min_vec = np.minimum(test_vec_ops_v1, test_vec_ops_v2)
 
 # Test matrix operations
 test_mat_ops_n = 2
-test_mat_ops_A = sparse.random(test_mat_ops_n, test_mat_ops_n, density=0.8).tocsc()
+test_mat_ops_A = sparse.random(test_mat_ops_n, test_mat_ops_n, density=0.8, format='csc')
 test_mat_ops_d = np.random.randn(test_mat_ops_n)
-D = sparse.diags(test_mat_ops_d).tocsc()
+D = sparse.diags(test_mat_ops_d, format='csc')
 test_mat_ops_prem_diag = D.dot(test_mat_ops_A).tocoo().tocsc()  # Force matrix reordering
 test_mat_ops_postm_diag = test_mat_ops_A.dot(D).tocoo().tocsc()  # Force matrix reordering
 test_mat_ops_inf_norm_cols = np.amax(np.abs(
@@ -45,10 +45,10 @@ p = 0.4
 
 test_mat_vec_n = n
 test_mat_vec_m = m
-test_mat_vec_A = sparse.random(m, n, density=1.0).tocsc()
-test_mat_vec_P = sparse.random(n, n, density=0.8).tocsc()
+test_mat_vec_A = sparse.random(m, n, density=1.0, format='csc')
+test_mat_vec_P = sparse.random(n, n, density=0.8, format='csc')
 test_mat_vec_P = test_mat_vec_P + test_mat_vec_P.T
-test_mat_vec_Pu = sparse.triu(test_mat_vec_P).tocsc()
+test_mat_vec_Pu = sparse.triu(test_mat_vec_P, format='csc')
 test_mat_vec_x = np.random.randn(n)
 test_mat_vec_y = np.random.randn(m)
 test_mat_vec_Ax = test_mat_vec_A.dot(test_mat_vec_x)
@@ -61,18 +61,18 @@ test_mat_vec_Px_cum = test_mat_vec_P.dot(test_mat_vec_x) + test_mat_vec_x
 
 # Test extract upper triangular
 test_mat_extr_triu_n = 5
-test_mat_extr_triu_P = sparse.random(test_mat_extr_triu_n, test_mat_extr_triu_n, density=0.8).tocsc()
+test_mat_extr_triu_P = sparse.random(test_mat_extr_triu_n, test_mat_extr_triu_n, density=0.8, format='csc')
 test_mat_extr_triu_P = test_mat_extr_triu_P + test_mat_extr_triu_P.T
-test_mat_extr_triu_Pu = sparse.triu(test_mat_extr_triu_P).tocsc()
+test_mat_extr_triu_Pu = sparse.triu(test_mat_extr_triu_P, format='csc')
 test_mat_extr_triu_P_inf_norm_cols = np.amax(np.abs(
     np.asarray(test_mat_extr_triu_P.todense())), axis=0)
 
 
 # Test compute quad form
 test_qpform_n = 4
-test_qpform_P = sparse.random(test_qpform_n, test_qpform_n, density=0.8).tocsc()
+test_qpform_P = sparse.random(test_qpform_n, test_qpform_n, density=0.8, format='csc')
 test_qpform_P = test_qpform_P + test_qpform_P.T
-test_qpform_Pu = sparse.triu(test_qpform_P).tocsc()
+test_qpform_Pu = sparse.triu(test_qpform_P, format='csc')
 test_qpform_x = np.random.randn(test_qpform_n)
 test_qpform_value = .5 * test_qpform_x.T.dot(test_qpform_P.dot(test_qpform_x))
 

--- a/tests/non_cvx/generate_problem.py
+++ b/tests/non_cvx/generate_problem.py
@@ -2,11 +2,10 @@ import numpy as np
 from scipy import sparse
 import utils.codegen_utils as cu
 
-P = sparse.triu([[2., 5.], [5., 1.]]).tocsc()
+P = sparse.triu([[2., 5.], [5., 1.]], format='csc')
 q = np.array([3., 4.])
 
-A = sparse.csc_matrix(np.array([[-1.0, 0.], [0., -1.], [-1., 3.],
-                                [2., 5.], [3., 4]]))
+A = sparse.csc_matrix([[-1., 0.], [0., -1.], [-1., 3.], [2., 5.], [3., 4]])
 l = -np.inf * np.ones(A.shape[0])
 u = np.array([0., 0., -15., 100., 80.])
 

--- a/tests/osqp_tester.c
+++ b/tests/osqp_tester.c
@@ -12,6 +12,7 @@
 // Include tests
 #include "lin_alg/test_lin_alg.h"
 #include "solve_linsys/test_solve_linsys.h"
+#include "demo/test_demo.h"
 #include "basic_qp/test_basic_qp.h"
 #include "basic_qp2/test_basic_qp2.h"
 #include "non_cvx/test_non_cvx.h"
@@ -27,6 +28,7 @@ int tests_run = 0;
 static const char* all_tests() {
   mu_run_test(test_lin_alg);
   mu_run_test(test_solve_linsys);
+  mu_run_test(test_demo);
   mu_run_test(test_basic_qp);
   mu_run_test(test_basic_qp2);
   mu_run_test(test_non_cvx);

--- a/tests/primal_dual_infeasibility/generate_problem.py
+++ b/tests/primal_dual_infeasibility/generate_problem.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import sparse
 import utils.codegen_utils as cu
 
-P = sparse.diags([1., 0.]).tocsc()
+P = sparse.diags([1., 0.], format='csc')
 q = np.array([1., -1.])
 
 A12 = sparse.csc_matrix([[1., 1.], [1., 0.], [0., 1.]])

--- a/tests/primal_infeasibility/generate_problem.py
+++ b/tests/primal_infeasibility/generate_problem.py
@@ -12,7 +12,7 @@ m = 150
 # Generate random Matrices
 Pt = sparse.random(n, n)
 P = Pt.T.dot(Pt) + sparse.eye(n)
-P = sparse.triu(P).tocsc()
+P = sparse.triu(P, format='csc')
 q = sp.randn(n)
 A = sparse.random(m, n).tolil()  # Lil for efficiency
 u = 3 + sp.randn(m)

--- a/tests/solve_linsys/generate_problem.py
+++ b/tests/solve_linsys/generate_problem.py
@@ -15,7 +15,7 @@ test_solve_KKT_P = sparse.random(test_solve_KKT_n, test_solve_KKT_n,
 test_solve_KKT_P = test_solve_KKT_P.dot(test_solve_KKT_P.T).tocsc()
 test_solve_KKT_A = sparse.random(test_solve_KKT_m, test_solve_KKT_n,
                                  density=0.4, format='csc')
-test_solve_KKT_Pu = sparse.triu(test_solve_KKT_P).tocsc()
+test_solve_KKT_Pu = sparse.triu(test_solve_KKT_P, format='csc')
 
 test_solve_KKT_rho = 4.0
 test_solve_KKT_sigma = 1.0
@@ -23,9 +23,10 @@ test_solve_KKT_KKT = sparse.vstack([
                         sparse.hstack([test_solve_KKT_P + test_solve_KKT_sigma *
                         sparse.eye(test_solve_KKT_n), test_solve_KKT_A.T]),
                         sparse.hstack([test_solve_KKT_A,
-                        -1./test_solve_KKT_rho * sparse.eye(test_solve_KKT_m)])]).tocsc()
+                        -1./test_solve_KKT_rho * sparse.eye(test_solve_KKT_m)])
+                        ], format='csc')
 test_solve_KKT_rhs = np.random.randn(test_solve_KKT_m + test_solve_KKT_n)
-test_solve_KKT_x = spla.splu(test_solve_KKT_KKT.tocsc()).solve(test_solve_KKT_rhs)
+test_solve_KKT_x = spla.splu(test_solve_KKT_KKT).solve(test_solve_KKT_rhs)
 
 test_solve_KKT_x[test_solve_KKT_n:] = test_solve_KKT_rhs[test_solve_KKT_n:] + \
                                       test_solve_KKT_x[test_solve_KKT_n:] / test_solve_KKT_rho

--- a/tests/unconstrained/generate_problem.py
+++ b/tests/unconstrained/generate_problem.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import sparse
 import utils.codegen_utils as cu
 
-P = sparse.diags([0.617022, 0.92032449, 0.20011437, 0.50233257, 0.34675589]).tocsc()
+P = sparse.diags([0.617022, 0.92032449, 0.20011437, 0.50233257, 0.34675589], format='csc')
 q = np.array([-1.10593508, -1.65451545, -2.3634686, 1.13534535, -1.01701414])
 A = sparse.csc_matrix((0,5))
 l = np.array([])

--- a/tests/update_matrices/generate_problem.py
+++ b/tests/update_matrices/generate_problem.py
@@ -13,18 +13,19 @@ test_form_KKT_n = n
 test_form_KKT_m = m
 p = 0.7
 
-test_form_KKT_A = sparse.random(test_form_KKT_m, test_form_KKT_n, density=p).tocsc()
+test_form_KKT_A = sparse.random(test_form_KKT_m, test_form_KKT_n, density=p, format='csc')
 test_form_KKT_P = sparse.random(n, n, density=p)
-test_form_KKT_P = test_form_KKT_P.dot(test_form_KKT_P.T).tocsc() + sparse.eye(n).tocsc()
-test_form_KKT_Pu = sparse.triu(test_form_KKT_P).tocsc()
+test_form_KKT_P = test_form_KKT_P.dot(test_form_KKT_P.T).tocsc() + sparse.eye(n, format='csc')
+test_form_KKT_Pu = sparse.triu(test_form_KKT_P, format='csc')
 test_form_KKT_rho = 1.6
 test_form_KKT_sigma = 0.1
 test_form_KKT_KKT = sparse.vstack([
                         sparse.hstack([test_form_KKT_P + test_form_KKT_sigma *
                         sparse.eye(test_form_KKT_n), test_form_KKT_A.T]),
                         sparse.hstack([test_form_KKT_A,
-                        -1./test_form_KKT_rho * sparse.eye(test_form_KKT_m)])]).tocsc()
-test_form_KKT_KKTu = sparse.triu(test_form_KKT_KKT).tocsc()
+                        -1./test_form_KKT_rho * sparse.eye(test_form_KKT_m)])
+                        ], format='csc')
+test_form_KKT_KKTu = sparse.triu(test_form_KKT_KKT, format='csc')
 
 
 # Create new P, A and KKT
@@ -38,8 +39,9 @@ test_form_KKT_KKT_new = sparse.vstack([
                         sparse.hstack([test_form_KKT_P_new + test_form_KKT_sigma *
                         sparse.eye(test_form_KKT_n), test_form_KKT_A_new.T]),
                         sparse.hstack([test_form_KKT_A_new,
-                        -1./test_form_KKT_rho * sparse.eye(test_form_KKT_m)])]).tocsc()
-test_form_KKT_KKTu_new = sparse.triu(test_form_KKT_KKT_new).tocsc()
+                        -1./test_form_KKT_rho * sparse.eye(test_form_KKT_m)])
+                        ], format='csc')
+test_form_KKT_KKTu_new = sparse.triu(test_form_KKT_KKT_new, format='csc')
 
 
 # Test solve problem with initial P and A

--- a/tests/update_matrices/test_update_matrices.h
+++ b/tests/update_matrices/test_update_matrices.h
@@ -133,9 +133,9 @@ static const char* test_update() {
 
   // Update P
   nnzP       = data->test_solve_Pu->p[data->test_solve_Pu->n];
-  Px_new_idx = (c_int*) c_malloc(nnzP * sizeof(c_int)); // Generate indices going from
-                                               // beginning to end of P
+  Px_new_idx = (c_int*) c_malloc(nnzP * sizeof(c_int));
 
+  // Generate indices going from beginning to end of P
   for (i = 0; i < nnzP; i++) {
     Px_new_idx[i] = i;
   }
@@ -146,32 +146,57 @@ static const char* test_update() {
   osqp_solve(work);
 
   // Compare solver statuses
-  mu_assert("Update matrices: problem with P updated, error in solver status!",
+  mu_assert("Update matrices: problem with updating P, error in solver status!",
             work->info->status_val == data->test_solve_P_new_status);
 
   // Compare primal solutions
-  mu_assert("Update matrices: problem with P updated, error in primal solution!",
+  mu_assert("Update matrices: problem with updating P, error in primal solution!",
             vec_norm_inf_diff(work->solution->x, data->test_solve_P_new_x,
                               data->n) < TESTS_TOL);
 
   // Compare dual solutions
-  mu_assert("Update matrices: problem with P updated, error in dual solution!",
+  mu_assert("Update matrices: problem with updating P, error in dual solution!",
             vec_norm_inf_diff(work->solution->y, data->test_solve_P_new_y,
                               data->m) < TESTS_TOL);
-
-
-  // Update A
-  nnzA       = data->test_solve_A->p[data->test_solve_A->n];
-  Ax_new_idx = (c_int*) c_malloc(nnzA * sizeof(c_int)); // Generate indices going from
-                                                        // beginning to end of A
-
-  for (i = 0; i < nnzA; i++) {
-    Ax_new_idx[i] = i;
-  }
 
   // Cleanup and setup workspace
   osqp_cleanup(work);
   exitflag = osqp_setup(&work, problem, settings);
+
+
+  // Update P (all indices)
+  osqp_update_P(work, data->test_solve_Pu_new->x, OSQP_NULL, nnzP);
+
+  // Solve Problem
+  osqp_solve(work);
+
+  // Compare solver statuses
+  mu_assert("Update matrices: problem with updating P (all indices), error in solver status!",
+            work->info->status_val == data->test_solve_P_new_status);
+
+  // Compare primal solutions
+  mu_assert("Update matrices: problem with updating P (all indices), error in primal solution!",
+            vec_norm_inf_diff(work->solution->x, data->test_solve_P_new_x,
+                              data->n) < TESTS_TOL);
+
+  // Compare dual solutions
+  mu_assert("Update matrices: problem with updating P (all indices), error in dual solution!",
+            vec_norm_inf_diff(work->solution->y, data->test_solve_P_new_y,
+                              data->m) < TESTS_TOL);
+
+  // Cleanup and setup workspace
+  osqp_cleanup(work);
+  exitflag = osqp_setup(&work, problem, settings);
+
+
+  // Update A
+  nnzA       = data->test_solve_A->p[data->test_solve_A->n];
+  Ax_new_idx = (c_int*) c_malloc(nnzA * sizeof(c_int));
+
+  // Generate indices going from beginning to end of A
+  for (i = 0; i < nnzA; i++) {
+    Ax_new_idx[i] = i;
+  }
 
   osqp_update_A(work, data->test_solve_A_new->x, Ax_new_idx, nnzA);
 
@@ -179,16 +204,41 @@ static const char* test_update() {
   osqp_solve(work);
 
   // Compare solver statuses
-  mu_assert("Update matrices: problem with A updated, error in solver status!",
+  mu_assert("Update matrices: problem with updating A, error in solver status!",
             work->info->status_val == data->test_solve_A_new_status);
 
   // Compare primal solutions
-  mu_assert("Update matrices: problem with A updated, error in primal solution!",
+  mu_assert("Update matrices: problem with updating A, error in primal solution!",
             vec_norm_inf_diff(work->solution->x, data->test_solve_A_new_x,
                               data->n) < TESTS_TOL);
 
   // Compare dual solutions
-  mu_assert("Update matrices: problem with A updated, error in dual solution!",
+  mu_assert("Update matrices: problem with updating A, error in dual solution!",
+            vec_norm_inf_diff(work->solution->y, data->test_solve_A_new_y,
+                              data->m) < TESTS_TOL);
+
+  // Cleanup and setup workspace
+  osqp_cleanup(work);
+  exitflag = osqp_setup(&work, problem, settings);
+
+
+  // Update A (all indices)
+  osqp_update_A(work, data->test_solve_A_new->x, OSQP_NULL, nnzA);
+
+  // Solve Problem
+  osqp_solve(work);
+
+  // Compare solver statuses
+  mu_assert("Update matrices: problem with updating A (all indices), error in solver status!",
+            work->info->status_val == data->test_solve_A_new_status);
+
+  // Compare primal solutions
+  mu_assert("Update matrices: problem with updating A (all indices), error in primal solution!",
+            vec_norm_inf_diff(work->solution->x, data->test_solve_A_new_x,
+                              data->n) < TESTS_TOL);
+
+  // Compare dual solutions
+  mu_assert("Update matrices: problem with updating A (all indices), error in dual solution!",
             vec_norm_inf_diff(work->solution->y, data->test_solve_A_new_y,
                               data->m) < TESTS_TOL);
 
@@ -197,6 +247,7 @@ static const char* test_update() {
   osqp_cleanup(work);
   exitflag = osqp_setup(&work, problem, settings);
 
+  // Update P and A
   osqp_update_P_A(work, data->test_solve_Pu_new->x, Px_new_idx, nnzP,
                   data->test_solve_A_new->x, Ax_new_idx, nnzA);
 
@@ -205,18 +256,47 @@ static const char* test_update() {
 
   // Compare solver statuses
   mu_assert(
-    "Update matrices: problem with P and A updated, error in solver status!",
+    "Update matrices: problem with updating P and A, error in solver status!",
     work->info->status_val == data->test_solve_P_A_new_status);
 
   // Compare primal solutions
   mu_assert(
-    "Update matrices: problem with P and A updated, error in primal solution!",
+    "Update matrices: problem with updating P and A, error in primal solution!",
     vec_norm_inf_diff(work->solution->x, data->test_solve_P_A_new_x,
                       data->n) < TESTS_TOL);
 
   // Compare dual solutions
   mu_assert(
-    "Update matrices: problem with P and A updated, error in dual solution!",
+    "Update matrices: problem with updating P and A, error in dual solution!",
+    vec_norm_inf_diff(work->solution->y, data->test_solve_P_A_new_y,
+                      data->m) < TESTS_TOL * TESTS_TOL);
+
+  // Cleanup and setup workspace
+  osqp_cleanup(work);
+  exitflag = osqp_setup(&work, problem, settings);
+
+
+  // Update P and A (all indices)
+  osqp_update_P_A(work, data->test_solve_Pu_new->x, OSQP_NULL, nnzP,
+                  data->test_solve_A_new->x, OSQP_NULL, nnzA);
+
+  // Solve Problem
+  osqp_solve(work);
+
+  // Compare solver statuses
+  mu_assert(
+    "Update matrices: problem with updating P and A (all indices), error in solver status!",
+    work->info->status_val == data->test_solve_P_A_new_status);
+
+  // Compare primal solutions
+  mu_assert(
+    "Update matrices: problem with updating P and A (all indices), error in primal solution!",
+    vec_norm_inf_diff(work->solution->x, data->test_solve_P_A_new_x,
+                      data->n) < TESTS_TOL);
+
+  // Compare dual solutions
+  mu_assert(
+    "Update matrices: problem with updating P and A (all indices), error in dual solution!",
     vec_norm_inf_diff(work->solution->y, data->test_solve_P_A_new_y,
                       data->m) < TESTS_TOL * TESTS_TOL);
 


### PR DESCRIPTION
- Coverage increased by 4%
- Fixed docs in `types.h` (when a comment is broken in more than one line, only first line is shown on the documentation website - see e.g. [here](https://osqp.org/docs/interfaces/cc++#_CPPv4N12OSQPSettings7scalingE))
- Fixed printing of polishing info in Python on Windows