### PR TITLE
WIP: Add user-specified custom timing functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,14 +41,23 @@ option (UNITTESTS "Enable unittests generation" OFF)
 #   1 :   Yes. Matrix update not allowed.
 #   2 :   Yes. Matrix update allowed.
 if (NOT DEFINED EMBEDDED)
+    set(EMBEDDED 0)
+endif()
+if (EMBEDDED EQUAL 2)
+    message(STATUS "Embedded is ON: Updating of vectors and matrices supported")
+elseif (EMBEDDED EQUAL 1)
+    message(STATUS "Embedded is ON: Updating of vectors supported")
+elseif (EMBEDDED EQUAL 0)
     message(STATUS "Embedded is OFF")
 else()
-    message(STATUS "Embedded is ${EMBEDDED}")
+    # If it is not a valid number, error
+    message(FATAL_ERROR "Undefined option ${EMBEDDED} for EMBEDDED")
 endif()
+
 
 # Is printing enabled?
 option (PRINTING "Enable solver printing" ON)
-if (DEFINED EMBEDDED)
+if (EMBEDDED)
     message(STATUS "Disabling printing for embedded")
     set(PRINTING OFF)
 endif()
@@ -57,7 +66,7 @@ message(STATUS "Printing is ${PRINTING}")
 
 # Is profiling enabled?
 option (PROFILING "Enable solver profiling (timing)" ON)
-if (DEFINED EMBEDDED)
+if (EMBEDDED)
     message(STATUS "Disabling profiling for embedded")
     set(PROFILING OFF)
 endif()
@@ -65,7 +74,7 @@ message(STATUS "Profiling is ${PROFILING}")
 
 # Is user interrupt enabled?
 option (CTRLC "Enable user interrupt (Ctrl-C)" ON)
-if (DEFINED EMBEDDED)
+if (EMBEDDED)
     message(STATUS "Disabling user interrupt for embedded")
     set(CTRLC OFF)
 endif()
@@ -73,7 +82,11 @@ message(STATUS "User interrupt is ${CTRLC}")
 
 # Use floats instead of integers
 option (DFLOAT "Use float numbers instead of doubles" OFF)
-message(STATUS "Floats are ${DFLOAT}")
+if (DFLOAT)
+    message(STATUS "Using single precision floats instead of doubles")
+else()
+    message(STATUS "Using double precision numbers")
+endif()
 
 # Use long integers for indexing
 option (DLONG "Use long integers (64bit) for indexing" ON)
@@ -119,7 +132,7 @@ option (ENABLE_MKL_PARDISO "Enable MKL Pardiso solver" ON)
 if (DFLOAT)
 	message(STATUS "Disabling MKL Pardiso Solver with floats")
 	set(ENABLE_MKL_PARDISO OFF)
-elseif(DEFINED EMBEDDED)
+elseif(EMBEDDED)
 	message(STATUS "Disabling MKL Pardiso Solver for embedded")
 	set(ENABLE_MKL_PARDISO OFF)
 endif()
@@ -197,7 +210,7 @@ set(
     include/util.h
 )
 
-if (DEFINED EMBEDDED)
+if (EMBEDDED)
     # osqp_src
     list(REMOVE_ITEM osqp_src "src/cs.c")
     list(REMOVE_ITEM osqp_src "src/ctrlc.c")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,11 +64,33 @@ endif()
 message(STATUS "Printing is ${PRINTING}")
 
 
+# Custom timing functions for profiling
+# ----------------------------------------------
+
+# This allows the user to specify custom functions to compute
+# the elapsed time for the profiling statistics.
+#
+# The user must specify a header file that contains definitions
+# for the osqp_tic and osqp_toc functions. The header should
+# contain definitions for:
+#   void osqp_tic(OSQPTimer *timer)
+#   c_float osqp_toc(OSQPTimer *timer)
+#   struct OSQP_TIMER
+# And the user must then manually link against these custom
+# functions.
+
+if(OSQP_CUSTOM_TICTOC)
+    message(STATUS "User custom tic and toc functions provided in: ${OSQP_CUSTOM_TICTOC}")
+endif()
+
 # Is profiling enabled?
 option (PROFILING "Enable solver profiling (timing)" ON)
-if (EMBEDDED)
-    message(STATUS "Disabling profiling for embedded")
-    set(PROFILING OFF)
+if (PROFILING)
+    if (EMBEDDED AND NOT OSQP_CUSTOM_TICTOC)
+        message(STATUS "Profiling for embedded mode requires OSQP_CUSTOM_TICTOC to be set")
+        message(STATUS "Disabling profiling for embedded")
+        set(PROFILING OFF)
+    endif()
 endif()
 message(STATUS "Profiling is ${PROFILING}")
 

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -111,3 +111,33 @@ ar -rcs ${TRAVIS_BUILD_DIR}/build/out/libosqp.a \
 #now make the rest of the demos and test
 make osqp_demo
 ${TRAVIS_BUILD_DIR}/build/out/osqp_demo
+
+
+# Test custom timing functions
+# ---------------------------------------------------
+
+echo "Test OSQP custom timing functions"
+cd ${TRAVIS_BUILD_DIR}
+rm -rf build
+mkdir build
+cd build
+cmake -DUNITTESTS=OFF \
+    -DOSQP_CUSTOM_TICTOC=${TRAVIS_BUILD_DIR}/tests/custom_tictoc/custom_tictoc.h \
+    ..
+#make the static library first: it will be missing symbols
+#for the custom memory functions
+make osqpstatic
+#compile the custom memory management functions
+g++ -c ${TRAVIS_BUILD_DIR}/tests/custom_tictoc/custom_tictoc.c \
+    -I ${TRAVIS_BUILD_DIR}/include \
+    -o ${TRAVIS_BUILD_DIR}/build/custom_tictoc.o
+#for testing purposes, just add this to osqp
+#static library.   For real applications, users
+#may prefer to keep it separate and link both
+#to their application
+ar -rcs ${TRAVIS_BUILD_DIR}/build/out/libosqp.a \
+        ${TRAVIS_BUILD_DIR}/build/custom_tictoc.o
+
+#now make the rest of the demos and test
+make osqp_demo
+${TRAVIS_BUILD_DIR}/build/out/osqp_demo

--- a/configure/osqp_configure.h.in
+++ b/configure/osqp_configure.h.in
@@ -21,6 +21,9 @@ extern "C" {
 
 /* PROFILING */
 #cmakedefine PROFILING
+#ifdef OSQP_CUSTOM_TICTOC
+#include "@OSQP_CUSTOM_TICTOC@"
+#endif
 
 /* CTRLC */
 #cmakedefine CTRLC

--- a/configure/osqp_configure.h.in
+++ b/configure/osqp_configure.h.in
@@ -21,9 +21,7 @@ extern "C" {
 
 /* PROFILING */
 #cmakedefine PROFILING
-#ifdef OSQP_CUSTOM_TICTOC
-#include "@OSQP_CUSTOM_TICTOC@"
-#endif
+#cmakedefine OSQP_CUSTOM_TICTOC "@OSQP_CUSTOM_TICTOC@"
 
 /* CTRLC */
 #cmakedefine CTRLC

--- a/include/util.h
+++ b/include/util.h
@@ -88,6 +88,8 @@ void print_footer(OSQPInfo *info,
 
 # ifdef PROFILING
 
+#  ifndef OSQP_CUSTOM_TICTOC
+
 // Windows
 #  ifdef IS_WINDOWS
 
@@ -119,7 +121,7 @@ struct OSQP_TIMER {
 };
 
 // Linux
-#  else // ifdef IS_WINDOWS
+#  elif defined IS_LINUX
 
 /* Use POSIX clock_gettime() for timing on non-Windows machines */
 #   include <time.h>
@@ -151,6 +153,8 @@ void    osqp_tic(OSQPTimer *t);
  * @return   Reported time
  */
 c_float osqp_toc(OSQPTimer *t);
+
+#  endif /* #ifndef OSQP_CUSTOM_TICTOC */
 
 # endif /* END #ifdef PROFILING */
 

--- a/lin_sys/CMakeLists.txt
+++ b/lin_sys/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Add subdirectory for each linear systems solver
 
-if (NOT DEFINED EMBEDDED)
+if (NOT EMBEDDED)
 # Include this directory for library handler
 # NB Needed for subfolders
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -14,7 +14,7 @@ add_subdirectory(direct)
 # TODO: Add!
 
 # Add linsys handler if not embedded
-if (NOT DEFINED EMBEDDED)
+if (NOT EMBEDDED)
 set(linsys_lib_handler
     ${CMAKE_CURRENT_SOURCE_DIR}/lib_handler.c
     ${CMAKE_CURRENT_SOURCE_DIR}/lib_handler.h)

--- a/lin_sys/direct/CMakeLists.txt
+++ b/lin_sys/direct/CMakeLists.txt
@@ -15,7 +15,7 @@ set(direct_linsys_solvers_includes
 
 
 # Add other solvers if embedded option is false
-if(NOT DEFINED EMBEDDED)
+if(NOT EMBEDDED)
 
 # MKL Pardiso MKL
 # -----------

--- a/lin_sys/direct/qdldl/CMakeLists.txt
+++ b/lin_sys/direct/qdldl/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_subdirectory(qdldl_sources)
 
 
-if(NOT DEFINED EMBEDDED)
+if(NOT EMBEDDED)
 set(
     amd_sources
     ${CMAKE_CURRENT_SOURCE_DIR}/amd/include/amd_internal.h

--- a/src/auxil.c
+++ b/src/auxil.c
@@ -6,6 +6,10 @@
 #include "scaling.h"
 #include "util.h"
 
+#ifdef OSQP_CUSTOM_TICTOC
+# include OSQP_CUSTOM_TICTOC
+#endif /* ifdef OSQP_CUSTOM_TICTOC */
+
 /***********************************************************
 * Auxiliary functions needed to compute ADMM iterations * *
 ***********************************************************/

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -18,6 +18,10 @@
 # include "lin_sys.h"
 #endif /* ifndef EMBEDDED */
 
+#ifdef OSQP_CUSTOM_TICTOC
+# include OSQP_CUSTOM_TICTOC
+#endif /* ifdef OSQP_CUSTOM_TICTOC */
+
 /**********************
 * Main API Functions *
 **********************/

--- a/src/polish.c
+++ b/src/polish.c
@@ -7,6 +7,10 @@
 #include "proj.h"
 #include "error.h"
 
+#ifdef OSQP_CUSTOM_TICTOC
+# include OSQP_CUSTOM_TICTOC
+#endif /* ifdef OSQP_CUSTOM_TICTOC */
+
 /**
  * Form reduced matrix A that contains only rows that are active at the
  * solution.
@@ -267,7 +271,7 @@ c_int polish(OSQPWorkspace *work) {
     // Memory clean-up
     csc_spfree(work->pol->Ared);
     c_free(rhs_red);
-  
+
     return -1;
   }
 
@@ -285,7 +289,7 @@ c_int polish(OSQPWorkspace *work) {
     csc_spfree(work->pol->Ared);
     c_free(rhs_red);
     c_free(pol_sol);
-  
+
     return -1;
   }
 

--- a/src/util.c
+++ b/src/util.c
@@ -307,7 +307,7 @@ c_float osqp_toc(OSQPTimer *t)
 }
 
 // Linux
-# else  /* ifdef IS_WINDOWS */
+# elif defined IS_LINUX
 
 /* read current time */
 void osqp_tic(OSQPTimer *t)

--- a/src/util.c
+++ b/src/util.c
@@ -1,5 +1,9 @@
 #include "util.h"
 
+#ifdef OSQP_CUSTOM_TICTOC
+# include OSQP_CUSTOM_TICTOC
+#endif /* ifdef OSQP_CUSTOM_TICTOC */
+
 /***************
 * Versioning  *
 ***************/
@@ -267,8 +271,10 @@ OSQPSettings* copy_settings(const OSQPSettings *settings) {
 
 #ifdef PROFILING
 
+# ifndef OSQP_CUSTOM_TICTOC
+
 // Windows
-# ifdef IS_WINDOWS
+#  ifdef IS_WINDOWS
 
 void osqp_tic(OSQPTimer *t)
 {
@@ -283,7 +289,7 @@ c_float osqp_toc(OSQPTimer *t)
 }
 
 // Mac
-# elif defined IS_MAC
+#  elif defined IS_MAC
 
 void osqp_tic(OSQPTimer *t)
 {
@@ -307,7 +313,7 @@ c_float osqp_toc(OSQPTimer *t)
 }
 
 // Linux
-# elif defined IS_LINUX
+#  elif defined IS_LINUX
 
 /* read current time */
 void osqp_tic(OSQPTimer *t)
@@ -332,7 +338,9 @@ c_float osqp_toc(OSQPTimer *t)
   return (c_float)temp.tv_sec + (c_float)temp.tv_nsec / 1e9;
 }
 
-# endif /* ifdef IS_WINDOWS */
+#  endif /* ifdef IS_WINDOWS */
+
+# endif /* ifndef OSQP_CUSTOM_TICTOC */
 
 #endif // If Profiling end
 

--- a/tests/custom_tictoc/custom_tictoc.c
+++ b/tests/custom_tictoc/custom_tictoc.c
@@ -1,0 +1,28 @@
+/*
+ * This file contains example functions for implementing custom timing
+ * routines. The function definitions are located in "custom_timing.h".
+ */
+
+#include "custom_tictoc.h"
+
+
+/*
+ * This is a custom osqp_tic function that initiailizes a counter
+ * variable to 0.
+ */
+void osqp_tic(OSQPTimer *timer)
+{
+  timer->cnt = 0;
+}
+
+
+
+/*
+ * This is a custom osqp_toc function that simply will count the number of times
+ * the timer object has been queried.
+ */
+c_float osqp_toc(OSQPTimer *timer)
+{
+  timer->cnt++;
+  return timer->cnt;
+}

--- a/tests/custom_tictoc/custom_tictoc.c
+++ b/tests/custom_tictoc/custom_tictoc.c
@@ -13,6 +13,8 @@
 void osqp_tic(OSQPTimer *timer)
 {
   timer->cnt = 0;
+
+  printf( "OSQP timing (tic)\n");
 }
 
 
@@ -24,5 +26,7 @@ void osqp_tic(OSQPTimer *timer)
 c_float osqp_toc(OSQPTimer *timer)
 {
   timer->cnt++;
+  printf( "OSQP timing (toc): %d calls\n", timer->cnt );
+
   return timer->cnt;
 }

--- a/tests/custom_tictoc/custom_tictoc.h
+++ b/tests/custom_tictoc/custom_tictoc.h
@@ -1,0 +1,29 @@
+/*
+ * Header file demonstrating definitions for custom functions for the tictoc
+ * timing functions. This header file is included in OSQP using the
+ * -DOSQP_CUSTOM_TICTOC flag.
+ */
+#ifndef CUSTOM_TICTOC_H_
+#define CUSTOM_TICTOC_H_
+
+
+# ifdef __cplusplus
+extern "C" {
+# endif /* ifdef __cplusplus */
+
+#include "types.h"
+#include "glob_opts.h"
+
+void osqp_tic(OSQPTimer *timer);
+c_float osqp_toc(OSQPTimer *timer);
+
+struct OSQP_TIMER {
+  int cnt;
+};
+
+
+# ifdef __cplusplus
+}
+# endif /* ifdef __cplusplus */
+
+#endif


### PR DESCRIPTION
This adds in the ability for users to specify custom `osqp_tic()` and `osqp_toc()` functions by providing a header file and then linking in the symbols. It was done similar to the custom memory allocators.

I have also cleaned up the cmake processing/error handling for the embedded flag, since it was very awkward and never let the user actually say that embedded is disabled.

The only limitation I can find so far is that the header file for the tic/toc functions cannot be the same as the header file for the memory allocators. If they are, then there is an issue with include ordering.

This is related to #153.