### PR TITLE
Solaris

### DIFF
--- a/configure/cmake/FindR.cmake
+++ b/configure/cmake/FindR.cmake
@@ -11,11 +11,22 @@ set(CMAKE_FIND_APPBUNDLE "NEVER")
 find_program(R_EXEC NAMES R R.exe)
 set(CMAKE_FIND_APPBUNDLE ${TEMP_CMAKE_FIND_APPBUNDLE})
 
+set(ENV{R_HOME} "blah")
 
 #---Find includes and libraries if R exists
 if(R_EXEC)
 
   set(R_FOUND TRUE)
+
+  # On CRAN/Solaris an R_HOME env variable is set and causes
+  # assignment of R_ROOT_DIR to fail since 'R RHOME'
+  # issues a warning as its first output.   Unset if needed.
+
+  # if((CMAKE_HOST_SOLARIS) AND (DEFINED ENV{R_HOME}))
+  if((TRUE) AND (DEFINED ENV{R_HOME}))
+      message(STATUS "Rogue R_HOME defined on Solaris.  Will ignore.")
+      unset(ENV{R_HOME})
+  endif()
 
   execute_process(WORKING_DIRECTORY .
   COMMAND ${R_EXEC} RHOME


### PR DESCRIPTION
Unsets the `R_HOME` environment variable manually when building OSQP for R on Solaris.

The existence of this environment variable causes a build fail on CRAN, since the R command `R RHOME` issues a warning as its first output, causing cmake to incorrectly assign `R_ROOT_DIR`.

This only appears to happen on the Solaris build, for reasons that remain shrouded in mystery.

NB: It would likely be harmless to call `unset(ENV{R_HOME})` on any platform, but this is a minimal intervention.