### PR TITLE
Make error macro C99 friendly

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -11,7 +11,13 @@ extern "C" {
 
 
 /* OSQP error macro */
+# if __STDC_VERSION__ >= 199901L
+/* The C99 standard gives the __func__ macro, which is preferred over __FUNCTION__ */
+#  define osqp_error(error_code) _osqp_error(error_code, __func__);
+#else
 #  define osqp_error(error_code) _osqp_error(error_code, __FUNCTION__);
+#endif
+
 
 
 /**


### PR DESCRIPTION
The C99 standard defines the __func__ macro for the function name, so that should be the preferred macro to use for C99 and later. This makes it a conditional define that uses __func__ if it is C99 or later, and __FUNCTION__ for the other cases (which will be compiler dependent).

This isn't actually an error when using C99 and GCC, but it triggers a warning that gets annoying.