### PR TITLE
CMake updates for embedded code generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,57 +159,11 @@ if (NOT MSVC)
     endif()
 endif (NOT MSVC)
 
-# Set sources
+# Set sources and includes
 # ----------------------------------------------
-set(
-    osqp_src
-    src/auxil.c
-    src/cs.c
-    src/ctrlc.c
-    src/error.c
-    src/kkt.c
-    src/lin_alg.c
-    src/lin_sys.c
-    src/osqp.c
-    src/polish.c
-    src/proj.c
-    src/scaling.c
-    src/util.c
-)
+add_subdirectory (src)
+add_subdirectory (include)
 
-set(
-    osqp_headers
-    include/auxil.h
-    include/constants.h
-    include/cs.h
-    include/ctrlc.h
-    include/error.h
-    include/glob_opts.h
-    include/kkt.h
-    include/lin_alg.h
-    include/lin_sys.h
-    include/osqp.h
-    include/osqp_configure.h
-    include/polish.h
-    include/proj.h
-    include/scaling.h
-    include/types.h
-    include/util.h
-)
-
-if (DEFINED EMBEDDED)
-    # osqp_src
-    list(REMOVE_ITEM osqp_src "src/cs.c")
-    list(REMOVE_ITEM osqp_src "src/ctrlc.c")
-    list(REMOVE_ITEM osqp_src "src/polish.c")
-    # osqp_headers
-    list(REMOVE_ITEM osqp_headers "include/ctrlc.h")
-    list(REMOVE_ITEM osqp_headers "include/cs.h")
-    list(REMOVE_ITEM osqp_headers "include/polish.h")
-elseif (NOT CTRLC)
-    list(REMOVE_ITEM osqp_src "src/ctrlc.c")
-    list(REMOVE_ITEM osqp_headers "include/ctrlc.h")
-endif()
 
 # if we are building the Python interface, let's look for Python
 # and set some options

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -60,7 +60,6 @@ cmake -G "Unix Makefiles" -DDLONG=OFF -DUNITTESTS=ON ..
 make
 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
 
-
 echo "Testing OSQP without printing"
 cd ${TRAVIS_BUILD_DIR}
 rm -rf build
@@ -69,6 +68,22 @@ cd build
 cmake -G "Unix Makefiles" -DPRINTING=OFF -DUNITTESTS=ON ..
 make
 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
+
+echo "Building OSQP with embedded=1"
+cd ${TRAVIS_BUILD_DIR}
+rm -rf build
+mkdir build
+cd build
+cmake -G "Unix Makefiles" -DEMBEDDED=1 ..
+make
+
+echo "Building OSQP with embedded=2"
+cd ${TRAVIS_BUILD_DIR}
+rm -rf build
+mkdir build
+cd build
+cmake -G "Unix Makefiles" -DEMBEDDED=2 ..
+make
 
 
 # Test custom memory management

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -60,15 +60,6 @@ cmake -G "Unix Makefiles" -DDLONG=OFF -DUNITTESTS=ON ..
 make
 ${TRAVIS_BUILD_DIR}/build/out/osqp_tester
 
-echo "Testing OSQP without printing"
-cd ${TRAVIS_BUILD_DIR}
-rm -rf build
-mkdir build
-cd build
-cmake -G "Unix Makefiles" -DPRINTING=OFF -DUNITTESTS=ON ..
-make
-${TRAVIS_BUILD_DIR}/build/out/osqp_tester
-
 echo "Building OSQP with embedded=1"
 cd ${TRAVIS_BUILD_DIR}
 rm -rf build
@@ -84,6 +75,15 @@ mkdir build
 cd build
 cmake -G "Unix Makefiles" -DEMBEDDED=2 ..
 make
+
+echo "Testing OSQP without printing"
+cd ${TRAVIS_BUILD_DIR}
+rm -rf build
+mkdir build
+cd build
+cmake -G "Unix Makefiles" -DPRINTING=OFF -DUNITTESTS=ON ..
+make
+${TRAVIS_BUILD_DIR}/build/out/osqp_tester
 
 
 # Test custom memory management

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Add the OSQP headers
+set(
+    osqp_headers
+    "${CMAKE_CURRENT_SOURCE_DIR}/auxil.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/constants.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/error.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/glob_opts.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/lin_sys.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/osqp.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/osqp_configure.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/proj.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/scaling.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/types.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/util.h"
+)
+
+# Add the KKT update only in normal mode and matrix-updating embedded mode (not mode 1)
+if (NOT (EMBEDDED EQUAL 1))
+    list(
+      APPEND
+      osqp_src
+      "${CMAKE_CURRENT_SOURCE_DIR}/kkt.h"
+    )
+endif()
+
+# Add more files that should only be in non-embedded code
+if (NOT DEFINED EMBEDDED)
+    list(
+      APPEND
+      osqp_headers
+      "${CMAKE_CURRENT_SOURCE_DIR}/cs.h"
+      "${CMAKE_CURRENT_SOURCE_DIR}/polish.h"
+    )
+endif()
+
+# Add the ctrl-c handler if enabled
+if (CTRLC)
+    list(
+      APPEND
+      osqp_headers
+      "${CMAKE_CURRENT_SOURCE_DIR}/ctrlc.h"
+    )
+endif()
+
+# Pass the header list up to the main CMakeLists scope
+set(
+  osqp_headers
+  "${osqp_headers}"
+  PARENT_SCOPE
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Add the OSQP sources
+set(
+    osqp_src
+    "${CMAKE_CURRENT_SOURCE_DIR}/auxil.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/error.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/lin_sys.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/osqp.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/proj.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/scaling.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/util.c"
+)
+
+# Add the KKT update only in normal mode and matrix-updating embedded mode (not mode 1)
+if (NOT (EMBEDDED EQUAL 1))
+    list(
+      APPEND
+      osqp_src
+      "${CMAKE_CURRENT_SOURCE_DIR}/kkt.c"
+    )
+endif()
+
+# Add more files that should only be in non-embedded code
+if (NOT DEFINED EMBEDDED)
+    list(
+      APPEND
+      osqp_src
+      "${CMAKE_CURRENT_SOURCE_DIR}/cs.c"
+      "${CMAKE_CURRENT_SOURCE_DIR}/polish.c"
+    )
+endif()
+
+# Add the ctrl-c handler if enabled
+if (CTRLC)
+    list(
+      APPEND
+      osqp_src
+      "${CMAKE_CURRENT_SOURCE_DIR}/ctrlc.c"
+    )
+endif()
+
+# Pass the source list up to the main CMakeLists scope
+set(
+  osqp_src
+  "${osqp_src}"
+  PARENT_SCOPE
+)

--- a/src/osqp.c
+++ b/src/osqp.c
@@ -30,7 +30,7 @@ void osqp_set_default_settings(OSQPSettings *settings) {
   settings->adaptive_rho           = ADAPTIVE_RHO;
   settings->adaptive_rho_interval  = ADAPTIVE_RHO_INTERVAL;
   settings->adaptive_rho_tolerance = (c_float)ADAPTIVE_RHO_TOLERANCE;
-  
+
 # ifdef PROFILING
   settings->adaptive_rho_fraction = (c_float)ADAPTIVE_RHO_FRACTION;
 # endif /* ifdef PROFILING */
@@ -564,13 +564,15 @@ c_int osqp_solve(OSQPWorkspace *work) {
     }
   }
 
+#ifdef PROFILING
   /* if time-limit reached check termination and update status accordingly */
  if (work->info->status_val == OSQP_TIME_LIMIT_REACHED) {
     if (!check_termination(work, 1)) { // Try for approximate solutions
       update_status(work->info, OSQP_TIME_LIMIT_REACHED); /* Change update status back to OSQP_TIME_LIMIT_REACHED */
     }
   }
-  
+#endif /* ifdef PROFILING */
+
 
 #if EMBEDDED != 1
   /* Update rho estimate */
@@ -1582,7 +1584,7 @@ c_int osqp_update_time_limit(OSQPWorkspace *work, c_float time_limit_new) {
 
   // Check if workspace has been initialized
   if (!work) osqp_error(OSQP_WORKSPACE_NOT_INIT_ERROR);
-  
+
   // Check that time_limit is nonnegative
   if (time_limit_new < 0.) {
 # ifdef PRINTING

--- a/tests/basic_qp/test_basic_qp.h
+++ b/tests/basic_qp/test_basic_qp.h
@@ -814,10 +814,18 @@ static const char* test_basic_qp_time_limit()
 	    work->info->status_val == sols_data->status_test);
 
   // Update time limit
+# ifdef PRINTING
   osqp_update_time_limit(work, 1e-5);
-  osqp_update_max_iter(work, (c_int)2e9);
   osqp_update_eps_rel(work, 1e-09);
   osqp_update_eps_abs(work, 1e-09);
+# else
+  // Not printing makes the code run a lot faster, so we need to make it work harder
+  // to fail by time limit exceeded
+  osqp_update_time_limit(work, 1e-5);
+  osqp_update_eps_rel(work, 1e-12);
+  osqp_update_eps_abs(work, 1e-12);
+# endif
+  osqp_update_max_iter(work, (c_int)2e9);
   osqp_update_check_termination(work, 0);
 
   // Solve Problem

--- a/tests/basic_qp/test_basic_qp.h
+++ b/tests/basic_qp/test_basic_qp.h
@@ -821,7 +821,7 @@ static const char* test_basic_qp_time_limit()
 # else
   // Not printing makes the code run a lot faster, so we need to make it work harder
   // to fail by time limit exceeded
-  osqp_update_time_limit(work, 1e-5);
+  osqp_update_time_limit(work, 1e-7);
   osqp_update_eps_rel(work, 1e-12);
   osqp_update_eps_abs(work, 1e-12);
 # endif


### PR DESCRIPTION
The main portion of the PR is to clean up the CMake list creation so it can simplify the upkeep of the CMake for the code generation routines. This moves the list creation into a CMakeLists inside the src and include folders, so now in code generation frameworks the main CMakeLists should just add these directories instead of having to keep a separate list of the files (which can become out of date as changes are made).

Additionally, the first commit fixes a build error that was introduced recently in embedded mode, and the last commit adds building of the embedded code to the Travis script so that any changes that might break embedded compilation will be caught in CI.