### PR TITLE
Have CMake handle conditional compilation of lin_sys.c/h

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -6,7 +6,6 @@ set(
     "${CMAKE_CURRENT_SOURCE_DIR}/error.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/glob_opts.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/lin_sys.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/osqp.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/osqp_configure.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/proj.h"
@@ -31,6 +30,7 @@ if (NOT DEFINED EMBEDDED)
       osqp_headers
       "${CMAKE_CURRENT_SOURCE_DIR}/cs.h"
       "${CMAKE_CURRENT_SOURCE_DIR}/polish.h"
+      "${CMAKE_CURRENT_SOURCE_DIR}/lin_sys.h"
     )
 endif()
 

--- a/include/lin_sys.h
+++ b/include/lin_sys.h
@@ -9,9 +9,6 @@ extern "C" {
 
 # include "types.h"
 
-# ifndef EMBEDDED
-
-
 /**
  * Load linear system solver shared library
  * @param	linsys_solver  Linear system solver
@@ -49,10 +46,6 @@ c_int init_linsys_solver(LinSysSolver          **s,
                          const c_float          *rho_vec,
                          enum linsys_solver_type linsys_solver,
                          c_int                   polish);
-
-
-# endif // EMBEDDED
-
 
 # ifdef __cplusplus
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,6 @@ set(
     "${CMAKE_CURRENT_SOURCE_DIR}/auxil.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/error.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.c"
-    "${CMAKE_CURRENT_SOURCE_DIR}/lin_sys.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/osqp.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/proj.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/scaling.c"
@@ -27,6 +26,7 @@ if (NOT DEFINED EMBEDDED)
       osqp_src
       "${CMAKE_CURRENT_SOURCE_DIR}/cs.c"
       "${CMAKE_CURRENT_SOURCE_DIR}/polish.c"
+      "${CMAKE_CURRENT_SOURCE_DIR}/lin_sys.c"
     )
 endif()
 

--- a/src/lin_sys.c
+++ b/src/lin_sys.c
@@ -11,9 +11,6 @@ const char *LINSYS_SOLVER_NAME[] = {
 # include "pardiso_loader.h"
 #endif /* ifdef ENABLE_MKL_PARDISO */
 
-
-#ifndef EMBEDDED
-
 // Load linear system solver shared library
 c_int load_linsys_solver(enum linsys_solver_type linsys_solver) {
   switch (linsys_solver) {
@@ -76,5 +73,3 @@ c_int init_linsys_solver(LinSysSolver          **s,
     return init_linsys_solver_qdldl((qdldl_solver **)s, P, A, sigma, rho_vec, polish);
   }
 }
-
-#endif /* ifndef EMBEDDED */


### PR DESCRIPTION
These files were completely ignored for embedded mode (#ifndef wrapped) but were still included in the CMake list of source files. This now has CMake ignore them, so the #ifndef is no longer needed.