### PR TITLE
update LDL etree error handling

### DIFF
--- a/lin_sys/direct/qdldl/qdldl_interface.c
+++ b/lin_sys/direct/qdldl/qdldl_interface.c
@@ -61,7 +61,13 @@ static c_int LDL_factor(csc *A,  qdldl_solver * p, c_int nvar){
     if (sum_Lnz < 0){
       // Error
 #ifdef PRINTING
-      c_eprint("Error in KKT matrix LDL factorization when computing the elimination tree. A is not perfectly upper triangular");
+      c_eprint("Error in KKT matrix LDL factorization when computing the elimination tree.");
+      if(sum_Lnz == -1){
+        c_eprint("Matrix is not perfectly upper triangular.");
+      }
+      else if(sum_Lnz == -2){
+        c_eprint("Integer overflow in L nonzero count.");
+      }
 #endif
       return sum_Lnz;
     }


### PR DESCRIPTION
Adds more detailed informational messages when `QDLDL_etree` returns an error code.    This is for compatibility with https://github.com/oxfordcontrol/qdldl/pull/25.

Note that I have not yet updated the qdldl submodule target.   I will do so when we tag a v.0.1.4 release for QDLDL for the above fix.