### PR TITLE
Set nzmax for qdldl L matrix

### DIFF
--- a/lin_sys/direct/qdldl/qdldl_interface.c
+++ b/lin_sys/direct/qdldl/qdldl_interface.c
@@ -69,6 +69,7 @@ static c_int LDL_factor(csc *A,  qdldl_solver * p, c_int nvar){
     // Allocate memory for Li and Lx
     p->L->i = (c_int *)c_malloc(sizeof(c_int)*sum_Lnz);
     p->L->x = (c_float *)c_malloc(sizeof(c_float)*sum_Lnz);
+    p->L->nzmax = sum_Lnz;
 
     // Factor matrix
     factor_status = QDLDL_factor(A->n, A->p, A->i, A->x,


### PR DESCRIPTION
The L matrix nzmax was not being set, so code generation resulted in a garbage value. This value is not used anywhere in the code though, so it doesn't seem to have had an observable effect on the solver.

Fixes oxfordcontrol/osqp-matlab#20