### PR TITLE
Documentation fix in the OSQPWorkspace struct.

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -229,7 +229,7 @@ typedef struct {
    */
   c_float *Ax;  ///< scaled A * x
   c_float *Px;  ///< scaled P * x
-  c_float *Aty; ///< scaled A * x
+  c_float *Aty; ///< scaled A' * y
 
   /** @} */
 


### PR DESCRIPTION
A quick documentation fix that should propagate through doxygen to the .rst documentation files.