### PR TITLE
Update CMakeLists.txt to use correct library directory under linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,7 +343,7 @@ endif()
 # Create CMake packages for the install directory
 # ----------------------------------------------
 
-set(ConfigPackageLocation lib/cmake/osqp)
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/osqp)
 
 install(EXPORT ${PROJECT_NAME}
         FILE osqp-targets.cmake


### PR DESCRIPTION
I found a some files that went into /usr/lib when building on 64-bit architectures
I think that if I build for 64-bit, it should go to /usr/lib64 with this changes.